### PR TITLE
issue 29

### DIFF
--- a/backend/apps/canteen/serializers.py
+++ b/backend/apps/canteen/serializers.py
@@ -1,8 +1,12 @@
+import re
 from decimal import Decimal
 
 from rest_framework import serializers
 
 from .models import Canteen, CanteenMenuCategory, CanteenMenuItem, CanteenPaymentConfig
+
+
+UPI_ID_PATTERN = re.compile(r"^[A-Za-z0-9._-]{2,64}@[A-Za-z0-9.-]{2,64}$")
 
 
 class CanteenMenuCategorySerializer(serializers.ModelSerializer):
@@ -106,6 +110,14 @@ class CanteenManagerStatsSerializer(serializers.Serializer):
 
 
 class CanteenPaymentConfigSerializer(serializers.ModelSerializer):
+    def validate_upi_id(self, value):
+        normalized_value = value.strip()
+        if not normalized_value:
+            return ""
+        if not UPI_ID_PATTERN.fullmatch(normalized_value):
+            raise serializers.ValidationError("Enter a valid UPI ID like yourname@bank.")
+        return normalized_value
+
     class Meta:
         model = CanteenPaymentConfig
         fields = ["id", "canteen", "upi_id", "qr_image_url", "payment_mode", "updated_at"]

--- a/backend/apps/canteen/test_payment_config.py
+++ b/backend/apps/canteen/test_payment_config.py
@@ -1,0 +1,43 @@
+from django.test import TestCase
+
+from .models import Canteen, CanteenPaymentConfig
+from .serializers import CanteenPaymentConfigSerializer
+
+
+class CanteenPaymentConfigSerializerTests(TestCase):
+    def setUp(self):
+        self.canteen = Canteen.objects.create(
+            name="Hall 3 Canteen",
+            location="Hall 3",
+        )
+        self.config = CanteenPaymentConfig.objects.create(canteen=self.canteen)
+
+    def test_accepts_valid_upi_id(self):
+        serializer = CanteenPaymentConfigSerializer(
+            self.config,
+            data={"upi_id": "canteen.payments@oksbi"},
+            partial=True,
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(serializer.validated_data["upi_id"], "canteen.payments@oksbi")
+
+    def test_rejects_invalid_upi_id(self):
+        serializer = CanteenPaymentConfigSerializer(
+            self.config,
+            data={"upi_id": "not a valid upi"},
+            partial=True,
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(serializer.errors["upi_id"][0], "Enter a valid UPI ID like yourname@bank.")
+
+    def test_trims_upi_id_before_saving(self):
+        serializer = CanteenPaymentConfigSerializer(
+            self.config,
+            data={"upi_id": "  canteen@upi  "},
+            partial=True,
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(serializer.validated_data["upi_id"], "canteen@upi")

--- a/frontend/src/pages/CanteenManagerDashboard.jsx
+++ b/frontend/src/pages/CanteenManagerDashboard.jsx
@@ -4,6 +4,23 @@ import axios from 'axios';
 import { Store, ClipboardList, Package, Users, Settings, Plus, Trash2, ToggleLeft, ToggleRight, LogOut, X, User, BarChart, CreditCard, Upload } from 'lucide-react';
 import '../features/canteen/canteen.css';
 
+const UPI_ID_PATTERN = /^[A-Za-z0-9._-]{2,64}@[A-Za-z0-9.-]{2,64}$/;
+
+const getUpiIdValidationError = (value) => {
+  if (!value) return '';
+  return UPI_ID_PATTERN.test(value) ? '' : 'Enter a valid UPI ID like yourname@bank.';
+};
+
+const extractPaymentConfigError = (data) => {
+  if (!data) return 'Failed to save payment settings.';
+  if (typeof data.detail === 'string') return data.detail;
+
+  const fieldError = [data.upi_id, data.qr_image_url, data.payment_mode]
+    .find((value) => Array.isArray(value) && typeof value[0] === 'string');
+
+  return fieldError?.[0] || 'Failed to save payment settings.';
+};
+
 const CanteenManagerDashboard = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState('canteen');
@@ -30,6 +47,8 @@ const CanteenManagerDashboard = () => {
 
   const token = localStorage.getItem('access_token');
   const headers = { Authorization: `Bearer ${token}` };
+  const normalizedUpiId = paymentSettings.upi_id.trim();
+  const upiIdValidationError = getUpiIdValidationError(normalizedUpiId);
 
   const fetchDeliveryPersonnel = async () => {
     setLoadingDelivery(true);
@@ -68,16 +87,27 @@ const CanteenManagerDashboard = () => {
 
   const savePaymentConfig = async () => {
     setPaymentError('');
+    if (upiIdValidationError) {
+      setPaymentError(upiIdValidationError);
+      return;
+    }
+
+    const nextPaymentSettings = {
+      ...paymentSettings,
+      upi_id: normalizedUpiId,
+    };
+
+    setPaymentSettings(nextPaymentSettings);
     try {
       await axios.put('/api/canteen-manager/payment-config/', {
-        upi_id: paymentSettings.upi_id,
-        payment_mode: paymentSettings.payment_mode,
-        qr_image_url: paymentSettings.qr_image_url,
+        upi_id: nextPaymentSettings.upi_id,
+        payment_mode: nextPaymentSettings.payment_mode,
+        qr_image_url: nextPaymentSettings.qr_image_url,
       }, { headers });
       setPaymentSaved(true);
       setTimeout(() => setPaymentSaved(false), 3000);
     } catch (err) {
-      setPaymentError(err.response?.data?.detail || 'Failed to save payment settings.');
+      setPaymentError(extractPaymentConfigError(err.response?.data));
     }
   };
 
@@ -315,16 +345,42 @@ const CanteenManagerDashboard = () => {
                   type="text"
                   placeholder="yourcanteen@upi"
                   value={paymentSettings.upi_id}
-                  onChange={(e) => { setPaymentSettings({ ...paymentSettings, upi_id: e.target.value }); setPaymentSaved(false); }}
-                  style={{ width: '100%', padding: 12, background: '#2a2a2a', border: '1px solid #444', borderRadius: 10, color: '#fff', fontSize: 14, marginBottom: 12, outline: 'none' }}
+                  onChange={(e) => {
+                    setPaymentSettings({ ...paymentSettings, upi_id: e.target.value });
+                    setPaymentSaved(false);
+                    setPaymentError('');
+                  }}
+                  style={{
+                    width: '100%',
+                    padding: 12,
+                    background: '#2a2a2a',
+                    border: upiIdValidationError ? '1px solid #d45555' : '1px solid #444',
+                    borderRadius: 10,
+                    color: '#fff',
+                    fontSize: 14,
+                    marginBottom: 12,
+                    outline: 'none',
+                  }}
                 />
+                {upiIdValidationError ? (
+                  <p style={{ margin: '-4px 0 12px', color: '#ff6b6b', fontSize: 12 }}>{upiIdValidationError}</p>
+                ) : (
+                  <p style={{ margin: '-4px 0 12px', color: '#888', fontSize: 12 }}>
+                    Use a valid UPI ID format like `yourcanteen@upi`.
+                  </p>
+                )}
 
                 <label style={{ fontSize: 12, color: '#999', marginBottom: 6, display: 'block' }}>Payment QR Code (URL or link)</label>
                 <input
                   type="text"
                   placeholder="https://example.com/your-qr-code.png (optional)"
                   value={paymentSettings.qr_image_url}
-                  onChange={(e) => { setPaymentSettings({ ...paymentSettings, qr_image_url: e.target.value }); setQrPreview(e.target.value); setPaymentSaved(false); }}
+                  onChange={(e) => {
+                    setPaymentSettings({ ...paymentSettings, qr_image_url: e.target.value });
+                    setQrPreview(e.target.value);
+                    setPaymentSaved(false);
+                    setPaymentError('');
+                  }}
                   style={{ width: '100%', padding: 12, background: '#2a2a2a', border: '1px solid #444', borderRadius: 10, color: '#fff', fontSize: 14, marginBottom: 12, outline: 'none' }}
                 />
                 {qrPreview && (
@@ -360,10 +416,12 @@ const CanteenManagerDashboard = () => {
               {/* Save Button */}
               <button
                 onClick={savePaymentConfig}
+                disabled={Boolean(upiIdValidationError)}
                 style={{
                   padding: 14, background: '#d45555', border: 'none', borderRadius: 10, color: '#fff',
                   fontWeight: 700, fontSize: 15, cursor: 'pointer', boxShadow: '0 0 15px rgba(232,85,85,0.15)',
                   transition: 'all 0.2s',
+                  opacity: upiIdValidationError ? 0.6 : 1,
                 }}
               >
                 {paymentSaved ? '✅ Saved!' : 'Save Payment Settings'}


### PR DESCRIPTION
## What changed
- added backend validation for canteen payment UPI IDs so invalid values are rejected and valid ones are trimmed before saving
- added client-side validation on the canteen manager payment settings screen with inline feedback and a disabled save action for invalid UPI IDs
- added focused serializer tests for valid, invalid, and trimmed UPI IDs

## Why
The payment settings form was accepting arbitrary text for the UPI ID field and saving it unchanged.

## Impact
Canteen managers can no longer save malformed UPI IDs, while valid UPI IDs continue to save successfully.

## Root cause
The upi_id field was posted from the frontend without validation, and the backend serializer accepted any string value.

## Validation
- python -m py_compile backend/apps/canteen/serializers.py backend/apps/canteen/test_payment_config.py
- serializer smoke check via Django shell for valid, invalid, and trimmed UPI IDs
- manual live verification in the running app and API: invalid UPI was rejected, valid UPI saved successfully

Closes #29