### PR TITLE
Issue 29

### DIFF
--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -472,17 +472,48 @@ class ManagerSerializer(serializers.ModelSerializer):
 class CreateMessSerializer(serializers.Serializer):
     """Serializer for admin manager to create a mess for a hall"""
     hall_name = serializers.CharField()
+    location = serializers.CharField(required=False, allow_blank=True)
 
     def validate_hall_name(self, value):
-        if Mess.objects.filter(hall_name=value).exists():
-            raise serializers.ValidationError(f"A mess for {value} already exists.")
-        return value
+        normalized_value = " ".join(value.split())
+        if not normalized_value:
+            raise serializers.ValidationError("Hall name cannot be blank.")
+        if Mess.objects.filter(hall_name__iexact=normalized_value).exists():
+            raise serializers.ValidationError(f"A mess for {normalized_value} already exists.")
+        return normalized_value
+
+    def validate_location(self, value):
+        return " ".join(value.split())
 
     def create(self, validated_data):
         mess = Mess.objects.create(
             hall_name=validated_data['hall_name'],
+            location=validated_data.get('location', ''),
         )
         return mess
+
+
+class UpdateMessSerializer(serializers.ModelSerializer):
+    """Serializer for admin manager to update mess details"""
+
+    class Meta:
+        model = Mess
+        fields = ['hall_name', 'location']
+
+    def validate_hall_name(self, value):
+        normalized_value = " ".join(value.split())
+        if not normalized_value:
+            raise serializers.ValidationError("Hall name cannot be blank.")
+
+        existing_messes = Mess.objects.filter(hall_name__iexact=normalized_value)
+        if self.instance is not None:
+            existing_messes = existing_messes.exclude(pk=self.instance.pk)
+        if existing_messes.exists():
+            raise serializers.ValidationError(f"A mess for {normalized_value} already exists.")
+        return normalized_value
+
+    def validate_location(self, value):
+        return " ".join(value.split())
 
 
 class MessListSerializer(serializers.ModelSerializer):
@@ -491,7 +522,7 @@ class MessListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Mess
-        fields = ['id', 'name', 'hall_name', 'hall_display', 'is_active', 'created_at']
+        fields = ['id', 'name', 'hall_name', 'hall_display', 'location', 'is_active', 'created_at']
         read_only_fields = fields
 
     def get_hall_display(self, obj):

--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -2,6 +2,7 @@ from django.utils import timezone
 from rest_framework.test import APITestCase
 
 from apps.canteen.models import Canteen
+from apps.mess.models import Mess
 from apps.orders.models import CanteenOrder
 from apps.users.models import Role, Staff, Student, User
 
@@ -87,3 +88,58 @@ class DeliveryPersonnelManagementTests(APITestCase):
         self.assertEqual(self.order.status, CanteenOrder.STATUS_READY)
         self.assertIsNone(self.order.delivery_person)
         self.assertIsNone(self.order.delivery_accepted_at)
+
+
+class AdminMessManagementTests(APITestCase):
+    def setUp(self):
+        self.admin_role = Role.objects.create(role_name="admin_manager")
+        self.admin_user = User.objects.create_user(
+            email="admin.manager@example.com",
+            password="password123",
+            role=self.admin_role,
+            is_active=True,
+            is_verified=True,
+        )
+        self.client.force_authenticate(user=self.admin_user)
+
+    def test_admin_can_update_mess_details(self):
+        mess = Mess.objects.create(hall_name="Hall 1", location="North Block")
+
+        response = self.client.put(
+            f"/api/admin/messes/{mess.id}/",
+            {"hall_name": "Hall 1 Extension", "location": "East Wing"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mess.refresh_from_db()
+        self.assertEqual(mess.hall_name, "Hall 1 Extension")
+        self.assertEqual(mess.name, "Hall 1 Extension Mess")
+        self.assertEqual(mess.location, "East Wing")
+        self.assertEqual(response.data["name"], "Hall 1 Extension Mess")
+        self.assertEqual(response.data["location"], "East Wing")
+
+    def test_admin_update_rejects_duplicate_hall_name(self):
+        Mess.objects.create(hall_name="Hall 1", location="North Block")
+        mess = Mess.objects.create(hall_name="Hall 2", location="South Block")
+
+        response = self.client.put(
+            f"/api/admin/messes/{mess.id}/",
+            {"hall_name": "Hall 1", "location": "South Block"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("hall_name", response.data)
+        mess.refresh_from_db()
+        self.assertEqual(mess.hall_name, "Hall 2")
+
+    def test_admin_can_toggle_mess_status(self):
+        mess = Mess.objects.create(hall_name="Hall 3", location="Central Block")
+
+        response = self.client.patch(f"/api/admin/messes/{mess.id}/", {}, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        mess.refresh_from_db()
+        self.assertFalse(mess.is_active)
+        self.assertEqual(response.data["is_active"], False)

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -509,33 +509,52 @@ class AdminMessManagementView(GenericAPIView):
             "id": mess.id,
             "name": mess.name,
             "hall_name": mess.hall_name,
+            "location": mess.location,
         }, status=status.HTTP_201_CREATED)
 
 
 class AdminMessDetailView(GenericAPIView):
-    """View to toggle status or delete a mess"""
+    """View to update, toggle status, or delete a mess"""
     permission_classes = [IsAuthenticated]
 
-    def patch(self, request, mess_id):
+    def put(self, request, pk):
         if not hasattr(request.user, 'role') or request.user.role.role_name != 'admin_manager':
             return Response({"detail": "Only admin managers can access this."}, status=status.HTTP_403_FORBIDDEN)
-        
-        from apps.mess.models import Mess
+
+        from .serializers import UpdateMessSerializer, MessListSerializer
         try:
-            mess = Mess.objects.get(id=mess_id)
+            mess = Mess.objects.get(id=pk)
+        except Mess.DoesNotExist:
+            return Response({"detail": "Mess not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        serializer = UpdateMessSerializer(mess, data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        updated_mess = serializer.save()
+        return Response({
+            "detail": f"Mess updated successfully: {updated_mess.name}",
+            **MessListSerializer(updated_mess).data,
+        })
+
+    def patch(self, request, pk):
+        if not hasattr(request.user, 'role') or request.user.role.role_name != 'admin_manager':
+            return Response({"detail": "Only admin managers can access this."}, status=status.HTTP_403_FORBIDDEN)
+
+        try:
+            mess = Mess.objects.get(id=pk)
             mess.is_active = not mess.is_active
             mess.save()
             return Response({"detail": f"Mess {'activated' if mess.is_active else 'frozen'} successfully.", "is_active": mess.is_active})
         except Mess.DoesNotExist:
             return Response({"detail": "Mess not found."}, status=status.HTTP_404_NOT_FOUND)
 
-    def delete(self, request, mess_id):
+    def delete(self, request, pk):
         if not hasattr(request.user, 'role') or request.user.role.role_name != 'admin_manager':
             return Response({"detail": "Only admin managers can access this."}, status=status.HTTP_403_FORBIDDEN)
-        
-        from apps.mess.models import Mess
+
         try:
-            mess = Mess.objects.get(id=mess_id)
+            mess = Mess.objects.get(id=pk)
             mess_name = mess.name
             mess.delete()
             return Response({"detail": f"Mess {mess_name} deleted successfully."})

--- a/frontend/src/pages/AdminManagerDashboard.jsx
+++ b/frontend/src/pages/AdminManagerDashboard.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   LogOut,
+  Pencil,
   Plus,
   ShieldCheck,
   Store,
@@ -24,6 +25,8 @@ import {
 } from '../lib/formValidation';
 import PullToRefresh from '../components/PullToRefresh';
 import './AdminManagerDashboard.css';
+
+const INITIAL_MESS_FORM_DATA = { hall_name: '', location: '' };
 
 const TAB_ITEMS = [
   { id: 'managers', label: 'Managers', icon: UserCog },
@@ -165,6 +168,7 @@ const EntitySectionSkeleton = ({ columns = 6 }) => (
 const DetailSheet = ({
   entity,
   onClose,
+  onEditMess,
   onToggleManager,
   onToggleMess,
   onToggleCanteen,
@@ -182,6 +186,7 @@ const DetailSheet = ({
   let details = [];
   let primaryAction = null;
   let secondaryAction = null;
+  let tertiaryAction = null;
 
   if (type === 'managers') {
     eyebrow = 'Manager';
@@ -209,6 +214,7 @@ const DetailSheet = ({
     subtitle = item.hall_display || 'Hall not set';
     details = [
       { label: 'Hall', value: item.hall_display || 'Not set' },
+      { label: 'Location', value: item.location || 'Not set' },
       { label: 'Status', value: item.is_active ? 'Active' : 'Inactive' },
     ];
     primaryAction = {
@@ -220,6 +226,12 @@ const DetailSheet = ({
       icon: ShieldCheck,
     };
     secondaryAction = {
+      label: 'Edit Mess',
+      className: 'admin-action-button',
+      onClick: () => onEditMess(item),
+      icon: Pencil,
+    };
+    tertiaryAction = {
       label: 'Delete Mess',
       className: 'admin-action-button admin-action-button--ghost',
       onClick: () => onDeleteMess(item.id),
@@ -253,6 +265,7 @@ const DetailSheet = ({
 
   const PrimaryIcon = primaryAction?.icon;
   const SecondaryIcon = secondaryAction?.icon;
+  const TertiaryIcon = tertiaryAction?.icon;
 
   return (
     <div className="admin-detail-backdrop" onClick={onClose}>
@@ -308,6 +321,17 @@ const DetailSheet = ({
               {secondaryAction.label}
             </button>
           ) : null}
+
+          {tertiaryAction ? (
+            <button
+              type="button"
+              className={tertiaryAction.className}
+              onClick={tertiaryAction.onClick}
+            >
+              {TertiaryIcon ? <TertiaryIcon size={16} /> : null}
+              {tertiaryAction.label}
+            </button>
+          ) : null}
         </div>
       </div>
     </div>
@@ -330,7 +354,8 @@ const AdminManagerDashboard = () => {
     canteen_id: '',
     mess_id: '',
   });
-  const [messFormData, setMessFormData] = useState({ hall_name: '' });
+  const [messFormData, setMessFormData] = useState(INITIAL_MESS_FORM_DATA);
+  const [editingMessId, setEditingMessId] = useState(null);
   const [canteenFormData, setCanteenFormData] = useState({ name: '', location: '' });
   const [message, setMessage] = useState({ type: '', text: '' });
   const [submittingType, setSubmittingType] = useState('');
@@ -391,8 +416,10 @@ const AdminManagerDashboard = () => {
 
   const closeAllForms = () => {
     setShowAddForm(false);
-    setShowAddMessForm(false);
     setShowAddCanteenForm(false);
+    setShowAddMessForm(false);
+    setEditingMessId(null);
+    setMessFormData(INITIAL_MESS_FORM_DATA);
   };
 
   const refreshManagers = useCallback(
@@ -423,9 +450,14 @@ const AdminManagerDashboard = () => {
   };
 
   const updateMessForm = (field, value) => {
+    const nextValueByField = {
+      hall_name: sanitizeEntityName(value, 120),
+      location: sanitizeLocationText(value, 200),
+    };
+
     setMessFormData((current) => ({
       ...current,
-      [field]: sanitizeEntityName(value, 120),
+      [field]: nextValueByField[field] ?? value,
     }));
     setMessage({ type: '', text: '' });
   };
@@ -500,23 +532,56 @@ const AdminManagerDashboard = () => {
     }
   };
 
-  const handleAddMess = async (event) => {
+  const resetMessForm = () => {
+    setMessFormData(INITIAL_MESS_FORM_DATA);
+    setEditingMessId(null);
+    setShowAddMessForm(false);
+  };
+
+  const getMessErrorMessage = (error, fallbackMessage) =>
+    error.response?.data?.hall_name?.[0] ||
+    error.response?.data?.hall_name ||
+    error.response?.data?.location?.[0] ||
+    error.response?.data?.location ||
+    error.response?.data?.detail ||
+    fallbackMessage;
+
+  const handleEditMess = (mess) => {
+    setSelectedEntity(null);
+    setMessage({ type: '', text: '' });
+    setEditingMessId(mess.id);
+    setMessFormData({
+      hall_name: mess.hall_name || '',
+      location: mess.location || '',
+    });
+    setShowAddForm(false);
+    setShowAddCanteenForm(false);
+    setShowAddMessForm(true);
+  };
+
+  const handleSaveMess = async (event) => {
     event.preventDefault();
     setSubmittingType('mess');
     setMessage({ type: '', text: '' });
 
     try {
-      const { data } = await api.post('/admin/messes/', messFormData);
-      setMessage({ type: 'success', text: `Mess created: ${data.name}` });
-      setMessFormData({ hall_name: '' });
-      setShowAddMessForm(false);
+      const { data } = editingMessId
+        ? await api.put(`/admin/messes/${editingMessId}/`, messFormData)
+        : await api.post('/admin/messes/', messFormData);
+      setMessage({
+        type: 'success',
+        text: editingMessId ? `Mess updated: ${data.name}` : `Mess created: ${data.name}`,
+      });
+      resetMessForm();
       await refreshMesses();
     } catch (error) {
-      const errorMessage =
-        error.response?.data?.hall_name?.[0] ||
-        error.response?.data?.detail ||
-        'Unable to create mess.';
-      setMessage({ type: 'error', text: errorMessage });
+      setMessage({
+        type: 'error',
+        text: getMessErrorMessage(
+          error,
+          editingMessId ? 'Unable to update mess.' : 'Unable to create mess.'
+        ),
+      });
     } finally {
       setSubmittingType('');
     }
@@ -562,6 +627,9 @@ const AdminManagerDashboard = () => {
       await api.patch(`/admin/messes/${messId}/`, {});
       setSelectedEntity(null);
       await refreshMesses();
+      if (editingMessId === messId) {
+        resetMessForm();
+      }
       setMessage({
         type: 'success',
         text: `Mess ${currentStatus ? 'frozen' : 'activated'} successfully.`,
@@ -580,6 +648,9 @@ const AdminManagerDashboard = () => {
       await api.delete(`/admin/messes/${messId}/`);
       setSelectedEntity(null);
       await refreshMesses();
+      if (editingMessId === messId) {
+        resetMessForm();
+      }
       setMessage({ type: 'success', text: 'Mess deleted successfully.' });
     } catch {
       setMessage({ type: 'error', text: 'Unable to delete mess.' });
@@ -655,7 +726,13 @@ const AdminManagerDashboard = () => {
     }
 
     if (activeTab === 'messes') {
-      setShowAddMessForm((current) => !current);
+      if (showAddMessForm) {
+        resetMessForm();
+      } else {
+        setEditingMessId(null);
+        setMessFormData(INITIAL_MESS_FORM_DATA);
+        setShowAddMessForm(true);
+      }
       setShowAddForm(false);
       setShowAddCanteenForm(false);
       return;
@@ -779,6 +856,7 @@ const AdminManagerDashboard = () => {
                 <tr>
                   <th>Mess Name</th>
                   <th>Hall</th>
+                  <th>Location</th>
                   <th>Status</th>
                   <th>Actions</th>
                 </tr>
@@ -788,11 +866,19 @@ const AdminManagerDashboard = () => {
                   <tr key={mess.id}>
                     <td>{mess.name}</td>
                     <td>{mess.hall_display}</td>
+                    <td>{mess.location || 'Not set'}</td>
                     <td>
                       <StatusBadge isActive={mess.is_active} type="messes" />
                     </td>
                     <td>
                       <div className="admin-action-row admin-action-row--desktop">
+                        <button
+                          type="button"
+                          className="admin-action-button"
+                          onClick={() => handleEditMess(mess)}
+                        >
+                          Edit
+                        </button>
                         <button
                           type="button"
                           className={`admin-action-button ${
@@ -1133,9 +1219,9 @@ const AdminManagerDashboard = () => {
               ) : null}
 
               {activeTab === 'messes' && showAddMessForm ? (
-                <form className="admin-form-panel" onSubmit={handleAddMess} noValidate>
-                  <div className="admin-form-grid admin-form-grid--single">
-                    <label className="admin-field admin-field--full">
+                <form className="admin-form-panel" onSubmit={handleSaveMess} noValidate>
+                  <div className="admin-form-grid">
+                    <label className="admin-field">
                       <span>Hall Name *</span>
                       <input
                         className="admin-input"
@@ -1146,6 +1232,17 @@ const AdminManagerDashboard = () => {
                         required
                       />
                     </label>
+
+                    <label className="admin-field">
+                      <span>Location</span>
+                      <input
+                        className="admin-input"
+                        placeholder="Optional location"
+                        value={messFormData.location}
+                        onChange={(event) => updateMessForm('location', event.target.value)}
+                        maxLength={200}
+                      />
+                    </label>
                   </div>
 
                   <div className="admin-form-actions">
@@ -1154,7 +1251,13 @@ const AdminManagerDashboard = () => {
                       className="admin-primary-button"
                       disabled={submittingType === 'mess'}
                     >
-                      {submittingType === 'mess' ? 'Creating...' : 'Create Mess'}
+                      {submittingType === 'mess'
+                        ? editingMessId
+                          ? 'Saving...'
+                          : 'Creating...'
+                        : editingMessId
+                          ? 'Save Changes'
+                          : 'Create Mess'}
                     </button>
                   </div>
                 </form>
@@ -1232,6 +1335,7 @@ const AdminManagerDashboard = () => {
         <DetailSheet
           entity={selectedEntity}
           onClose={() => setSelectedEntity(null)}
+          onEditMess={handleEditMess}
           onToggleManager={handleToggleStatus}
           onToggleMess={handleToggleMess}
           onToggleCanteen={handleToggleCanteen}


### PR DESCRIPTION
## What changed
Added a real admin mess edit flow so mess details can be updated instead of only added or deleted.

## Why
The admin dashboard exposed add, freeze, and delete actions for messes, but there was no way to edit existing mess information.

## Impact
Admins can now open a mess in the dashboard, edit hall details and location, and save changes through a dedicated backend update endpoint.

## Validation
- Frontend build completed successfully with Vite
- Backend Python files passed py_compile
- Django DB-backed tests could not be run here because the local environment does not have the configured PostgreSQL service for deployment_v4
