### PR TITLE
Issue #7: Scan History not showing failed scans - Dheeraj

### DIFF
--- a/backend/apps/mess/tests/test_worker_api.py
+++ b/backend/apps/mess/tests/test_worker_api.py
@@ -23,6 +23,7 @@ class MessWorkerAPITests(APITestCase):
         self.other_worker_user, self.other_worker_staff = self._create_worker_user("2")
         self.student_user, self.student = self._create_student_user("1")
         MessAccount.objects.create(student=self.student, balance=Decimal("10000.00"))
+        current_day = timezone.localdate().strftime("%A").lower()
 
         self.mess = Mess.objects.create(
             name="Hall Mess 1",
@@ -56,7 +57,7 @@ class MessWorkerAPITests(APITestCase):
             description="Main item",
             price=Decimal("40.00"),
             meal_type=MessMenuItem.MealType.LUNCH,
-            day_of_week=MessMenuItem.DayOfWeek.MONDAY,
+            day_of_week=current_day,
             available_quantity=300,
             default_quantity=300,
             is_active=True,
@@ -67,7 +68,7 @@ class MessWorkerAPITests(APITestCase):
             description="Other mess item",
             price=Decimal("50.00"),
             meal_type=MessMenuItem.MealType.SNACK,
-            day_of_week=MessMenuItem.DayOfWeek.TUESDAY,
+            day_of_week=current_day,
             available_quantity=300,
             default_quantity=300,
             is_active=True,
@@ -268,6 +269,8 @@ class MessWorkerAPITests(APITestCase):
         self.assertEqual(len(response.data), 2)
         self.assertEqual(response.data[0]["id"], booking_2.id)
         self.assertEqual(response.data[1]["id"], booking_1.id)
+        self.assertEqual(response.data[0]["scan_status"], "success")
+        self.assertEqual(response.data[1]["scan_status"], "success")
 
     def test_scan_history_fallback_query_when_cache_is_empty(self):
         booking_1 = create_booking(self.student, self.menu_item.id, quantity=1)
@@ -299,3 +302,47 @@ class MessWorkerAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["id"], booking_for_worker_1.id)
+
+    def test_scan_history_includes_failed_invalid_qr_attempts(self):
+        self._auth_worker()
+        verify_response = self.client.post(
+            "/api/mess/worker/verify/",
+            {"qr_code": "invalid-qr"},
+            format="json",
+        )
+        self.assertEqual(verify_response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        history_response = self.client.get("/api/mess/worker/scan-history/")
+        self.assertEqual(history_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(history_response.data), 1)
+        self.assertEqual(history_response.data[0]["scan_status"], "failed")
+        self.assertEqual(history_response.data[0]["failure_reason"], "Invalid QR code.")
+        self.assertEqual(history_response.data[0]["identifier_type"], "qr_code")
+        self.assertIsNone(history_response.data[0]["menu_item"])
+
+    def test_scan_history_keeps_failed_attempts_alongside_successful_scans(self):
+        booking = create_booking(self.student, self.menu_item.id, quantity=1)
+
+        self._auth_worker()
+        first_response = self.client.post(
+            "/api/mess/worker/verify/",
+            {"booking_id": booking.id},
+            format="json",
+        )
+        self.assertEqual(first_response.status_code, status.HTTP_200_OK)
+
+        duplicate_response = self.client.post(
+            "/api/mess/worker/verify/",
+            {"booking_id": booking.id},
+            format="json",
+        )
+        self.assertEqual(duplicate_response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        history_response = self.client.get("/api/mess/worker/scan-history/")
+        self.assertEqual(history_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(history_response.data), 2)
+        self.assertEqual(history_response.data[0]["scan_status"], "failed")
+        self.assertEqual(history_response.data[0]["id"], booking.id)
+        self.assertEqual(history_response.data[0]["booking_reference"], history_response.data[1]["booking_reference"])
+        self.assertEqual(history_response.data[1]["scan_status"], "success")
+        self.assertNotEqual(history_response.data[0]["entry_id"], history_response.data[1]["entry_id"])

--- a/backend/apps/mess/views.py
+++ b/backend/apps/mess/views.py
@@ -1,5 +1,6 @@
 import re
 from decimal import Decimal
+from uuid import uuid4
 
 from django.core.cache import cache
 from django.http import HttpResponse
@@ -31,6 +32,8 @@ from .services import QRGenerationError, build_booking_qr_payload, generate_book
 
 WORKER_SCAN_HISTORY_TTL_SECONDS = 2 * 60 * 60
 WORKER_SCAN_HISTORY_LIMIT = 20
+WORKER_SCAN_STATUS_SUCCESS = "success"
+WORKER_SCAN_STATUS_FAILED = "failed"
 
 
 def _natural_sort_key(value):
@@ -122,32 +125,162 @@ def _worker_scan_history_cache_key(staff_id):
     return f"mess:worker:scan-history:{staff_id}"
 
 
-def _record_worker_scan_history(staff_id, booking_id):
-    key = _worker_scan_history_cache_key(staff_id)
-    existing_ids = cache.get(key, [])
-    if not isinstance(existing_ids, (list, tuple)):
-        existing_ids = []
-
-    normalized_existing_ids = []
-    for item_id in existing_ids:
-        try:
-            parsed_id = int(item_id)
-        except (TypeError, ValueError):
-            continue
-        if parsed_id != int(booking_id):
-            normalized_existing_ids.append(parsed_id)
-
-    normalized_ids = [int(booking_id)] + normalized_existing_ids
-    cache.set(key, normalized_ids[:WORKER_SCAN_HISTORY_LIMIT], timeout=WORKER_SCAN_HISTORY_TTL_SECONDS)
+def _safe_int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
-def _get_worker_scan_history_ids(staff_id):
+def _extract_worker_scan_error_message(detail):
+    if isinstance(detail, dict):
+        first_key = next(iter(detail), None)
+        if first_key is None:
+            return "Verification failed."
+        return _extract_worker_scan_error_message(detail[first_key])
+
+    if isinstance(detail, (list, tuple)):
+        if not detail:
+            return "Verification failed."
+        return _extract_worker_scan_error_message(detail[0])
+
+    text = str(detail).strip()
+    return text or "Verification failed."
+
+
+def _normalize_worker_scan_history_entry(raw_entry):
+    if isinstance(raw_entry, dict):
+        scan_status = raw_entry.get("scan_status")
+        if scan_status not in {WORKER_SCAN_STATUS_SUCCESS, WORKER_SCAN_STATUS_FAILED}:
+            return None
+
+        booking_id = _safe_int(raw_entry.get("booking_id"))
+        if scan_status == WORKER_SCAN_STATUS_SUCCESS and booking_id is None:
+            return None
+
+        normalized_entry = {
+            "entry_id": str(raw_entry.get("entry_id") or uuid4().hex),
+            "scan_status": scan_status,
+            "attempted_at": raw_entry.get("attempted_at"),
+        }
+        if booking_id is not None:
+            normalized_entry["booking_id"] = booking_id
+
+        attempted_booking_id = _safe_int(raw_entry.get("attempted_booking_id"))
+        if attempted_booking_id is not None:
+            normalized_entry["attempted_booking_id"] = attempted_booking_id
+
+        if scan_status == WORKER_SCAN_STATUS_FAILED:
+            failure_reason = raw_entry.get("failure_reason")
+            if failure_reason:
+                normalized_entry["failure_reason"] = str(failure_reason)
+
+            identifier_type = raw_entry.get("identifier_type")
+            if identifier_type in {"booking_id", "qr_code"}:
+                normalized_entry["identifier_type"] = identifier_type
+
+        return normalized_entry
+
+    legacy_booking_id = _safe_int(raw_entry)
+    if legacy_booking_id is None:
+        return None
+
+    return {
+        "entry_id": f"legacy-success-{legacy_booking_id}",
+        "scan_status": WORKER_SCAN_STATUS_SUCCESS,
+        "booking_id": legacy_booking_id,
+    }
+
+
+def _get_worker_scan_history_entries(staff_id):
     key = _worker_scan_history_cache_key(staff_id)
     values = cache.get(key, [])
-    try:
-        return [int(item) for item in values]
-    except (TypeError, ValueError):
+    if not isinstance(values, (list, tuple)):
         return []
+
+    normalized_entries = []
+    for raw_entry in values:
+        normalized_entry = _normalize_worker_scan_history_entry(raw_entry)
+        if normalized_entry is not None:
+            normalized_entries.append(normalized_entry)
+
+    return normalized_entries[:WORKER_SCAN_HISTORY_LIMIT]
+
+
+def _set_worker_scan_history_entries(staff_id, entries):
+    cache.set(
+        _worker_scan_history_cache_key(staff_id),
+        entries[:WORKER_SCAN_HISTORY_LIMIT],
+        timeout=WORKER_SCAN_HISTORY_TTL_SECONDS,
+    )
+
+
+def _record_worker_scan_history(staff_id, *, scan_status, booking=None, failure_reason=None, payload=None):
+    payload = payload or {}
+    attempted_booking_id = _safe_int(payload.get("booking_id"))
+    identifier_type = "booking_id" if attempted_booking_id is not None else ("qr_code" if payload.get("qr_code") else None)
+
+    history_entry = {
+        "entry_id": uuid4().hex,
+        "scan_status": scan_status,
+        "attempted_at": timezone.now().isoformat(),
+    }
+    if booking is not None:
+        history_entry["booking_id"] = booking.id
+    if attempted_booking_id is not None:
+        history_entry["attempted_booking_id"] = attempted_booking_id
+    if scan_status == WORKER_SCAN_STATUS_FAILED:
+        history_entry["failure_reason"] = str(failure_reason or "Verification failed.")
+        if identifier_type:
+            history_entry["identifier_type"] = identifier_type
+
+    existing_entries = _get_worker_scan_history_entries(staff_id)
+    if scan_status == WORKER_SCAN_STATUS_SUCCESS and booking is not None:
+        existing_entries = [
+            entry
+            for entry in existing_entries
+            if not (
+                entry.get("scan_status") == WORKER_SCAN_STATUS_SUCCESS
+                and entry.get("booking_id") == booking.id
+            )
+        ]
+
+    _set_worker_scan_history_entries(staff_id, [history_entry, *existing_entries])
+
+
+def _build_worker_scan_history_response_entry(entry, *, booking=None, booking_data=None):
+    response_entry = dict(booking_data or {})
+    if not response_entry:
+        fallback_id = entry.get("attempted_booking_id") or entry.get("booking_id") or entry["entry_id"]
+        response_entry = {
+            "id": fallback_id,
+            "menu_item": None,
+            "quantity": None,
+            "total_price": None,
+            "meal_type": None,
+            "booking_date": None,
+            "status": None,
+            "qr_expires_at": None,
+            "created_at": entry.get("attempted_at"),
+            "booking_reference": None,
+        }
+
+    attempted_at = entry.get("attempted_at")
+    if attempted_at is None and booking is not None:
+        attempted_at = (booking.redeemed_at or booking.updated_at or booking.created_at).isoformat()
+
+    response_entry["entry_id"] = entry.get("entry_id") or f"success-{response_entry['id']}"
+    response_entry["scan_status"] = entry.get("scan_status", WORKER_SCAN_STATUS_SUCCESS)
+    response_entry["attempted_at"] = attempted_at or response_entry.get("created_at")
+
+    if response_entry["scan_status"] == WORKER_SCAN_STATUS_FAILED:
+        response_entry["failure_reason"] = entry.get("failure_reason") or "Verification failed."
+        response_entry["identifier_type"] = entry.get("identifier_type")
+        response_entry["attempted_booking_id"] = entry.get("attempted_booking_id")
+        if not response_entry.get("booking_reference") and entry.get("attempted_booking_id"):
+            response_entry["booking_reference"] = f"Booking #{entry['attempted_booking_id']}"
+
+    return response_entry
 
 
 def _parse_bool(value, field_name):
@@ -525,9 +658,32 @@ class WorkerVerifyBookingView(generics.GenericAPIView):
                 "allowed_mess_id": worker_assignment.mess_id,
             },
         )
-        serializer.is_valid(raise_exception=True)
-        booking = serializer.save(staff=staff)
-        _record_worker_scan_history(staff.id, booking.id)
+        try:
+            serializer.is_valid(raise_exception=True)
+            booking = serializer.save(staff=staff)
+        except ValidationError as exc:
+            booking = None
+            if getattr(serializer, "validated_data", None):
+                try:
+                    booking = serializer.get_booking()
+                except ValidationError:
+                    booking = None
+
+            _record_worker_scan_history(
+                staff.id,
+                scan_status=WORKER_SCAN_STATUS_FAILED,
+                booking=booking,
+                failure_reason=_extract_worker_scan_error_message(exc.detail),
+                payload=payload,
+            )
+            raise
+
+        _record_worker_scan_history(
+            staff.id,
+            scan_status=WORKER_SCAN_STATUS_SUCCESS,
+            booking=booking,
+            payload=payload,
+        )
         return Response(
             MessBookingDetailSerializer(booking, context={"request": request}).data,
             status=status.HTTP_200_OK,
@@ -541,19 +697,57 @@ class WorkerScanHistoryView(APIView):
         staff = _get_staff_from_request(request)
         worker_assignment = _get_worker_assignment(request)
 
-        cached_ids = _get_worker_scan_history_ids(staff.id)
-        queryset = MessBooking.objects.select_related("menu_item", "menu_item__mess", "redeemed_by_staff").filter(
+        cached_entries = _get_worker_scan_history_entries(staff.id)
+        bookings_queryset = MessBooking.objects.select_related("menu_item", "menu_item__mess", "redeemed_by_staff").filter(
             menu_item__mess_id=worker_assignment.mess_id,
-            redeemed_by_staff=staff,
-            status=MessBooking.Status.REDEEMED,
         )
 
-        if cached_ids:
-            queryset = queryset.filter(id__in=cached_ids)
-            bookings_by_id = {booking.id: booking for booking in queryset}
-            ordered_bookings = [bookings_by_id[booking_id] for booking_id in cached_ids if booking_id in bookings_by_id]
+        if cached_entries:
+            booking_ids = [
+                entry["booking_id"]
+                for entry in cached_entries
+                if entry.get("booking_id") is not None
+            ]
+            bookings = list(bookings_queryset.filter(id__in=booking_ids))
+            bookings_by_id = {booking.id: booking for booking in bookings}
+            serialized_bookings = MessBookingListSerializer(
+                bookings,
+                many=True,
+                context={"request": request},
+            ).data
+            booking_data_by_id = {item["id"]: item for item in serialized_bookings}
+            data = [
+                _build_worker_scan_history_response_entry(
+                    entry,
+                    booking=bookings_by_id.get(entry.get("booking_id")),
+                    booking_data=booking_data_by_id.get(entry.get("booking_id")),
+                )
+                for entry in cached_entries
+            ]
         else:
-            ordered_bookings = list(queryset.order_by("-redeemed_at", "-updated_at")[:WORKER_SCAN_HISTORY_LIMIT])
+            ordered_bookings = list(
+                bookings_queryset.filter(
+                    redeemed_by_staff=staff,
+                    status=MessBooking.Status.REDEEMED,
+                ).order_by("-redeemed_at", "-updated_at")[:WORKER_SCAN_HISTORY_LIMIT]
+            )
+            serialized_bookings = MessBookingListSerializer(
+                ordered_bookings,
+                many=True,
+                context={"request": request},
+            ).data
+            booking_data_by_id = {item["id"]: item for item in serialized_bookings}
+            data = [
+                _build_worker_scan_history_response_entry(
+                    {
+                        "entry_id": f"success-{booking.id}",
+                        "scan_status": WORKER_SCAN_STATUS_SUCCESS,
+                        "booking_id": booking.id,
+                    },
+                    booking=booking,
+                    booking_data=booking_data_by_id.get(booking.id),
+                )
+                for booking in ordered_bookings
+            ]
 
-        data = MessBookingListSerializer(ordered_bookings, many=True, context={"request": request}).data
         return Response(data, status=status.HTTP_200_OK)

--- a/frontend/src/features/mess/pages/ScanHistoryPage.jsx
+++ b/frontend/src/features/mess/pages/ScanHistoryPage.jsx
@@ -5,6 +5,37 @@ import { useIncrementalList } from '../../../hooks/useIncrementalList';
 import { useScanHistory } from '../hooks/useScanHistory';
 import '../mess.css';
 
+const formatAttemptTime = (value) => {
+  if (!value) {
+    return 'Time unavailable';
+  }
+
+  const parsedDate = new Date(value);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return 'Time unavailable';
+  }
+
+  return parsedDate.toLocaleString('en-IN', {
+    day: '2-digit',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true,
+  });
+};
+
+const getFallbackScanLabel = (scan) => {
+  if (scan.attempted_booking_id) {
+    return `Booking #${scan.attempted_booking_id}`;
+  }
+
+  if (scan.identifier_type === 'qr_code') {
+    return 'QR scan attempt';
+  }
+
+  return 'Scan attempt';
+};
+
 const ScanHistoryPage = () => {
   const navigate = useNavigate();
   const { data: scans, isLoading, isError } = useScanHistory();
@@ -21,7 +52,9 @@ const ScanHistoryPage = () => {
   return (
     <div className="mess-page">
       <div className="mess-page-header">
-        <button className="mess-back-btn" onClick={() => navigate('/worker/scan')}><ArrowLeft size={18} /></button>
+        <button className="mess-back-btn" onClick={() => navigate('/worker/scan')}>
+          <ArrowLeft size={18} />
+        </button>
         <h1 className="mess-page-title">Scan History</h1>
       </div>
 
@@ -29,33 +62,77 @@ const ScanHistoryPage = () => {
         <h3 className="mess-section-title" style={{ marginBottom: 16 }}>Recent Scans</h3>
 
         {isLoading ? (
-          <div className="mess-loading"><div className="mess-loading-spinner" /><span className="mess-loading-text">Loading scan history...</span></div>
+          <div className="mess-loading">
+            <div className="mess-loading-spinner" />
+            <span className="mess-loading-text">Loading scan history...</span>
+          </div>
         ) : isError ? (
           <div className="mess-error">Scan history currently not available.</div>
         ) : (scans || []).length === 0 ? (
-          <div className="mess-empty"><div className="mess-empty-icon">📷</div><div>No scans yet in this session</div></div>
+          <div className="mess-empty">
+            <div className="mess-empty-icon">QR</div>
+            <div>No scans yet in this session</div>
+          </div>
         ) : (
           <>
-          {visibleScans.map((scan) => (
-            <div key={scan.id} className="mess-booking-card" style={{ cursor: 'default' }}>
-              <div className="mess-booking-header">
-                <span className="mess-booking-id">{scan.booking_reference || `#${scan.id}`}</span>
-                <span className="mess-status-badge redeemed">✓ Valid</span>
-              </div>
-              <div className="mess-booking-details">{scan.menu_item?.item_name} · ₹{scan.total_price}</div>
-              <div className="mess-booking-details">Qty: {scan.quantity} · {scan.meal_type}</div>
-              <div className="mess-booking-details" style={{ color: '#00ff00' }}>
-                Redeemed: {new Date(scan.created_at).toLocaleString('en-IN', { hour: '2-digit', minute: '2-digit', hour12: true })}
-              </div>
-            </div>
-          ))
-          }
-          <InfiniteScrollSentinel
-            hasMore={hasMore}
-            onLoadMore={loadMore}
-            skeletonCount={2}
-            minHeight={112}
-          />
+            {visibleScans.map((scan) => {
+              const isFailed = scan.scan_status === 'failed';
+              const statusBadgeClass = isFailed ? 'cancelled' : 'redeemed';
+              const statusText = isFailed ? 'Failed' : 'Valid';
+              const bookingLabel = scan.booking_reference || getFallbackScanLabel(scan);
+              const itemLabel = scan.menu_item?.item_name || getFallbackScanLabel(scan);
+              const quantityAndMeal = [
+                scan.quantity ? `Qty: ${scan.quantity}` : null,
+                scan.meal_type,
+              ]
+                .filter(Boolean)
+                .join(' · ');
+              const amountLabel = scan.total_price != null ? ` · Rs${scan.total_price}` : '';
+              const timeLabel = `${isFailed ? 'Failed' : 'Verified'}: ${formatAttemptTime(
+                scan.attempted_at || scan.created_at
+              )}`;
+
+              return (
+                <div
+                  key={scan.entry_id || scan.id}
+                  className="mess-booking-card"
+                  style={{ cursor: 'default' }}
+                >
+                  <div className="mess-booking-header">
+                    <span className="mess-booking-id">{bookingLabel}</span>
+                    <span className={`mess-status-badge ${statusBadgeClass}`}>{statusText}</span>
+                  </div>
+
+                  <div className="mess-booking-details">
+                    {itemLabel}
+                    {amountLabel}
+                  </div>
+
+                  {quantityAndMeal ? (
+                    <div className="mess-booking-details">{quantityAndMeal}</div>
+                  ) : null}
+
+                  {isFailed ? (
+                    <div className="mess-booking-details" style={{ color: '#ff8f8f' }}>
+                      {scan.failure_reason || 'Verification failed.'}
+                    </div>
+                  ) : null}
+
+                  <div
+                    className="mess-booking-details"
+                    style={{ color: isFailed ? '#ff6666' : '#00ff00' }}
+                  >
+                    {timeLabel}
+                  </div>
+                </div>
+              );
+            })}
+            <InfiniteScrollSentinel
+              hasMore={hasMore}
+              onLoadMore={loadMore}
+              skeletonCount={2}
+              minHeight={112}
+            />
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- record failed mess worker verification attempts in scan history without changing the database schema
- return mixed success and failure history entries from the worker scan history API
- render failed scans on the worker Scan History page with the error reason

## Validation
- docker exec upside_dine_backend sh -lc 'cd /tmp/backend_issue7 && python manage.py test apps.mess.tests.test_worker_api'
- docker exec upside_dine_frontend sh -lc 'ln -sfn /app/node_modules /tmp/frontend_issue7/node_modules && cd /tmp/frontend_issue7 && npm run build'