### PR TITLE
Issue 28 - unable to delete Extra items from mess

### DIFF
--- a/backend/apps/mess/tests/test_manager_api.py
+++ b/backend/apps/mess/tests/test_manager_api.py
@@ -20,10 +20,12 @@ class MessManagerAPITests(APITestCase):
     def setUp(self):
         cache.clear()
         self.manager_user, self.manager_staff = self._create_manager_user("1")
+        MessStaffAssignment.objects.filter(staff=self.manager_staff).update(is_active=False)
         self.student_user, self.student = self._create_student_user("1")
         self.other_student_user, self.other_student = self._create_student_user("2")
         MessAccount.objects.create(student=self.student, balance=Decimal("10000.00"))
         MessAccount.objects.create(student=self.other_student, balance=Decimal("10000.00"))
+        self.current_day = timezone.localdate().strftime("%A").lower()
 
         self.mess = Mess.objects.create(
             name="Hall Mess 1",
@@ -50,7 +52,7 @@ class MessManagerAPITests(APITestCase):
             description="Tasty roll",
             price=Decimal("40.00"),
             meal_type=MessMenuItem.MealType.LUNCH,
-            day_of_week=MessMenuItem.DayOfWeek.MONDAY,
+            day_of_week=self.current_day,
             available_quantity=300,
             default_quantity=320,
             is_active=True,
@@ -61,7 +63,7 @@ class MessManagerAPITests(APITestCase):
             description="Inactive item",
             price=Decimal("25.00"),
             meal_type=MessMenuItem.MealType.BREAKFAST,
-            day_of_week=MessMenuItem.DayOfWeek.MONDAY,
+            day_of_week=self.current_day,
             available_quantity=100,
             default_quantity=100,
             is_active=False,
@@ -72,7 +74,7 @@ class MessManagerAPITests(APITestCase):
             description="Other mess item",
             price=Decimal("50.00"),
             meal_type=MessMenuItem.MealType.SNACK,
-            day_of_week=MessMenuItem.DayOfWeek.TUESDAY,
+            day_of_week=self.current_day,
             available_quantity=200,
             default_quantity=200,
             is_active=True,
@@ -177,7 +179,17 @@ class MessManagerAPITests(APITestCase):
 
         returned_ids = {item["id"] for item in response.data}
         self.assertIn(self.menu_item.id, returned_ids)
+        self.assertNotIn(self.menu_item_inactive.id, returned_ids)
+        self.assertNotIn(self.other_mess_item.id, returned_ids)
+
+    def test_manager_menu_list_can_filter_inactive_items(self):
+        self._auth_manager()
+        response = self.client.get("/api/mess/manager/menu/", {"is_active": "false"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        returned_ids = {item["id"] for item in response.data}
         self.assertIn(self.menu_item_inactive.id, returned_ids)
+        self.assertNotIn(self.menu_item.id, returned_ids)
         self.assertNotIn(self.other_mess_item.id, returned_ids)
 
     def test_manager_menu_filter_by_meal_type(self):
@@ -264,6 +276,11 @@ class MessManagerAPITests(APITestCase):
 
         self.menu_item.refresh_from_db()
         self.assertFalse(self.menu_item.is_active)
+
+        list_response = self.client.get("/api/mess/manager/menu/")
+        self.assertEqual(list_response.status_code, status.HTTP_200_OK)
+        returned_ids = {item["id"] for item in list_response.data}
+        self.assertNotIn(self.menu_item.id, returned_ids)
 
     def test_manager_bookings_default_today_with_stats(self):
         today = timezone.localdate()
@@ -366,7 +383,7 @@ class MessManagerAPITests(APITestCase):
             description="Snack special",
             price=Decimal("70.00"),
             meal_type=MessMenuItem.MealType.SNACK,
-            day_of_week=MessMenuItem.DayOfWeek.FRIDAY,
+            day_of_week=self.current_day,
             available_quantity=100,
             default_quantity=100,
             is_active=True,

--- a/backend/apps/mess/views.py
+++ b/backend/apps/mess/views.py
@@ -465,7 +465,14 @@ class ManagerMenuListCreateView(generics.ListCreateAPIView):
 
     def get_queryset(self):
         mess = _get_manager_mess(self.request)
-        return MessMenuItem.objects.select_related("mess").filter(mess=mess).order_by(
+        queryset = MessMenuItem.objects.select_related("mess").filter(mess=mess)
+        is_active_value = self.request.query_params.get("is_active")
+        if is_active_value is not None:
+            _parse_bool(is_active_value, "is_active")
+        if is_active_value is None:
+            queryset = queryset.filter(is_active=True)
+
+        return queryset.order_by(
             "day_of_week",
             "meal_type",
             "item_name",


### PR DESCRIPTION
## Summary
- default the mess manager extras list to active items so soft-deleted extras disappear from the page
- keep the explicit `is_active` filter working for managers who need to inspect inactive extras
- add regression coverage for inactive filtering, delete visibility, and stabilize the manager API tests against current manager assignment/date rules

## Root Cause
Deleting a mess extra only soft-deactivated the record. The manager list endpoint still returned inactive extras by default, so the deleted item stayed visible after the frontend refreshed and it looked like deletion had failed.

## Validation
- `docker exec upside_dine_backend sh -lc "cd /tmp/backend_issue28 && python manage.py test apps.mess.tests.test_manager_api"`
- focused manager API shell validation confirming the deleted extra no longer appears in `/api/mess/manager/menu/` after delete
