### PR TITLE
Issue 30 - mess worker info should be editable

### DIFF
--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -717,3 +717,58 @@ Upside Dine Team'''
             'temp_password': temp_password,
             'employee_code': employee_code,
         }
+
+
+class UpdateMessWorkerSerializer(serializers.Serializer):
+    """Serializer for mess managers to update worker contact details."""
+    full_name = serializers.CharField(required=False, max_length=100)
+    email = serializers.EmailField(required=False)
+    phone = serializers.CharField(required=False, allow_blank=True, max_length=20)
+
+    def validate(self, attrs):
+        allowed_fields = set(self.fields.keys())
+        unknown_fields = set(self.initial_data.keys()) - allowed_fields
+        if unknown_fields:
+            raise serializers.ValidationError(
+                {field: ["This field cannot be updated."] for field in sorted(unknown_fields)}
+            )
+
+        if not attrs:
+            raise serializers.ValidationError("Provide at least one field to update.")
+
+        return attrs
+
+    def validate_full_name(self, value):
+        normalized_value = " ".join(value.split())
+        if not normalized_value:
+            raise serializers.ValidationError("Full name cannot be blank.")
+        return normalized_value
+
+    def validate_email(self, value):
+        normalized_value = value.lower()
+        existing_users = User.objects.filter(email=normalized_value)
+        if self.instance is not None:
+            existing_users = existing_users.exclude(pk=self.instance.pk)
+        if existing_users.exists():
+            raise serializers.ValidationError("A user with this email already exists.")
+        return normalized_value
+
+    def validate_phone(self, value):
+        return value.strip()
+
+    def update(self, instance, validated_data):
+        user_fields = []
+        for field in ("email", "phone"):
+            if field in validated_data:
+                setattr(instance, field, validated_data[field])
+                user_fields.append(field)
+
+        if user_fields:
+            instance.save(update_fields=user_fields)
+
+        if "full_name" in validated_data:
+            staff_profile = instance.staff_profile
+            staff_profile.full_name = validated_data["full_name"]
+            staff_profile.save(update_fields=["full_name"])
+
+        return instance

--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from rest_framework.test import APITestCase
 
 from apps.canteen.models import Canteen
-from apps.mess.models import Mess
+from apps.mess.models import Mess, MessStaffAssignment
 from apps.orders.models import CanteenOrder
 from apps.users.models import Role, Staff, Student, User
 
@@ -200,6 +200,130 @@ class DeliveryPersonnelManagementTests(APITestCase):
         self.assertEqual(self.order.status, CanteenOrder.STATUS_READY)
         self.assertIsNone(self.order.delivery_person)
         self.assertIsNone(self.order.delivery_accepted_at)
+
+
+class MessWorkerManagementTests(APITestCase):
+    def setUp(self):
+        self.mess = Mess.objects.create(hall_name="Hall 7", location="Zone A", is_active=True)
+        self.other_mess = Mess.objects.create(hall_name="Hall 8", location="Zone B", is_active=True)
+        self.manager_role = Role.objects.create(role_name="mess_manager")
+        self.worker_role = Role.objects.create(role_name="mess_worker")
+        self.student_role = Role.objects.create(role_name="student")
+
+        self.manager = User.objects.create_user(
+            email="mess.manager@example.com",
+            password="password123",
+            role=self.manager_role,
+            is_active=True,
+            is_verified=True,
+        )
+        self.manager_staff = Staff.objects.create(
+            user=self.manager,
+            full_name="Mess Manager",
+            employee_code="MM001",
+            is_mess_staff=True,
+        )
+        MessStaffAssignment.objects.filter(staff=self.manager_staff).update(is_active=False)
+        MessStaffAssignment.objects.create(
+            staff=self.manager_staff,
+            mess=self.mess,
+            assignment_role="manager",
+            is_active=True,
+        )
+
+        self.worker = User.objects.create_user(
+            email="worker.one@example.com",
+            password="password123",
+            phone="9999999999",
+            role=self.worker_role,
+            is_active=True,
+            is_verified=True,
+        )
+        self.worker_staff = Staff.objects.create(
+            user=self.worker,
+            full_name="Worker One",
+            employee_code="MW001",
+            is_mess_staff=True,
+        )
+        MessStaffAssignment.objects.create(
+            staff=self.worker_staff,
+            mess=self.mess,
+            assignment_role="worker",
+            is_active=True,
+        )
+
+        self.other_worker = User.objects.create_user(
+            email="worker.two@example.com",
+            password="password123",
+            phone="8888888888",
+            role=self.worker_role,
+            is_active=True,
+            is_verified=True,
+        )
+        self.other_worker_staff = Staff.objects.create(
+            user=self.other_worker,
+            full_name="Worker Two",
+            employee_code="MW002",
+            is_mess_staff=True,
+        )
+        MessStaffAssignment.objects.create(
+            staff=self.other_worker_staff,
+            mess=self.other_mess,
+            assignment_role="worker",
+            is_active=True,
+        )
+
+        self.duplicate_user = User.objects.create_user(
+            email="duplicate@example.com",
+            password="password123",
+            role=self.student_role,
+            is_active=True,
+            is_verified=True,
+        )
+
+        self.client.force_authenticate(user=self.manager)
+
+    def test_manager_can_update_mess_worker_details(self):
+        response = self.client.patch(
+            f"/api/manager/mess-workers/{self.worker.id}/",
+            {
+                "full_name": "Updated Worker",
+                "email": "updated.worker@example.com",
+                "phone": "7777777777",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.worker.refresh_from_db()
+        self.worker_staff.refresh_from_db()
+        self.assertEqual(self.worker.email, "updated.worker@example.com")
+        self.assertEqual(self.worker.phone, "7777777777")
+        self.assertEqual(self.worker_staff.full_name, "Updated Worker")
+        self.assertEqual(response.data["email"], "updated.worker@example.com")
+        self.assertEqual(response.data["phone"], "7777777777")
+        self.assertEqual(response.data["full_name"], "Updated Worker")
+
+    def test_manager_update_rejects_duplicate_worker_email(self):
+        response = self.client.patch(
+            f"/api/manager/mess-workers/{self.worker.id}/",
+            {"email": self.duplicate_user.email},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("email", response.data)
+        self.worker.refresh_from_db()
+        self.assertEqual(self.worker.email, "worker.one@example.com")
+
+    def test_manager_cannot_update_worker_from_other_mess(self):
+        response = self.client.patch(
+            f"/api/manager/mess-workers/{self.other_worker.id}/",
+            {"full_name": "No Access"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 404)
 
 
 class AdminMessManagementTests(APITestCase):

--- a/backend/apps/users/urls.py
+++ b/backend/apps/users/urls.py
@@ -22,6 +22,7 @@ from .views import (
     AvailableHallsView,
     PublicCanteensView,
     MessWorkerManagementView,
+    MessWorkerDetailView,
     ToggleMessWorkerStatusView,
 )
 
@@ -47,5 +48,6 @@ urlpatterns = [
     path("public/halls/", AvailableHallsView.as_view(), name="public-halls"),
     path("public/canteens/", PublicCanteensView.as_view(), name="public-canteens"),
     path("manager/mess-workers/", MessWorkerManagementView.as_view(), name="mess-worker-management"),
+    path("manager/mess-workers/<int:user_id>/", MessWorkerDetailView.as_view(), name="mess-worker-detail"),
     path("manager/mess-workers/<int:user_id>/toggle/", ToggleMessWorkerStatusView.as_view(), name="toggle-mess-worker-status"),
 ]

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -36,6 +36,32 @@ def _natural_sort_key(value):
     return [int(part) if part.isdigit() else part.lower() for part in parts]
 
 
+def _get_managed_mess_worker(request, user_id):
+    if not hasattr(request.user, 'role') or request.user.role.role_name != 'mess_manager':
+        return None, Response({"detail": "Only mess managers can manage workers."}, status=status.HTTP_403_FORBIDDEN)
+
+    manager_staff = getattr(request.user, 'staff_profile', None)
+    if manager_staff is None:
+        return None, Response({"detail": "Mess manager profile not found."}, status=status.HTTP_403_FORBIDDEN)
+
+    from apps.mess.models import MessStaffAssignment
+
+    manager_assignment = MessStaffAssignment.objects.filter(
+        staff=manager_staff, assignment_role='manager', is_active=True
+    ).first()
+    if not manager_assignment:
+        return None, Response({"detail": "You are not assigned to any mess."}, status=status.HTTP_403_FORBIDDEN)
+
+    worker_assignment = MessStaffAssignment.objects.filter(
+        mess=manager_assignment.mess, assignment_role='worker', staff__user_id=user_id
+    ).select_related('staff__user').first()
+
+    if not worker_assignment:
+        return None, Response({"detail": "Worker not found in your mess."}, status=status.HTTP_404_NOT_FOUND)
+
+    return worker_assignment.staff.user, None
+
+
 class RegisterView(GenericAPIView):
     permission_classes = [AllowAny]
     serializer_class = RegisterSerializer
@@ -705,31 +731,31 @@ class MessWorkerManagementView(GenericAPIView):
         }, status=status.HTTP_201_CREATED)
 
 
+class MessWorkerDetailView(GenericAPIView):
+    """View for mess managers to update worker details."""
+    permission_classes = [IsAuthenticated]
+
+    def patch(self, request, user_id):
+        worker, error = _get_managed_mess_worker(request, user_id)
+        if error:
+            return error
+
+        from .serializers import MessWorkerSerializer, UpdateMessWorkerSerializer
+
+        serializer = UpdateMessWorkerSerializer(worker, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        updated_worker = serializer.save()
+
+        return Response(MessWorkerSerializer(updated_worker).data, status=status.HTTP_200_OK)
+
+
 class ToggleMessWorkerStatusView(GenericAPIView):
     """View for mess managers to toggle or delete mess workers"""
     permission_classes = [IsAuthenticated]
 
     def _get_worker(self, request, user_id):
         """Helper to validate manager and find the worker"""
-        if not hasattr(request.user, 'role') or request.user.role.role_name != 'mess_manager':
-            return None, Response({"detail": "Only mess managers can manage workers."}, status=status.HTTP_403_FORBIDDEN)
-
-        from apps.mess.models import MessStaffAssignment
-        manager_assignment = MessStaffAssignment.objects.filter(
-            staff=request.user.staff_profile, assignment_role='manager', is_active=True
-        ).first()
-        if not manager_assignment:
-            return None, Response({"detail": "You are not assigned to any mess."}, status=status.HTTP_403_FORBIDDEN)
-
-        # Ensure the worker belongs to the same mess
-        worker_assignment = MessStaffAssignment.objects.filter(
-            mess=manager_assignment.mess, assignment_role='worker', staff__user_id=user_id
-        ).select_related('staff__user').first()
-
-        if not worker_assignment:
-            return None, Response({"detail": "Worker not found in your mess."}, status=status.HTTP_404_NOT_FOUND)
-
-        return worker_assignment.staff.user, None
+        return _get_managed_mess_worker(request, user_id)
 
     def patch(self, request, user_id):
         """Toggle worker active status (freeze/unfreeze)"""

--- a/frontend/src/pages/MessManagerDashboard.jsx
+++ b/frontend/src/pages/MessManagerDashboard.jsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   ClipboardList,
   LogOut,
+  Pencil,
   Plus,
   Settings,
   ToggleLeft,
@@ -26,6 +27,7 @@ import {
 import '../features/mess/mess.css';
 
 const MESS_MANAGER_WORKERS_QUERY_KEY = ['mess-manager', 'workers'];
+const EMPTY_WORKER_FORM = { full_name: '', email: '', phone: '' };
 
 const WorkerListSkeleton = () => (
   <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
@@ -64,7 +66,8 @@ const MessManagerDashboard = () => {
   const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState('mess');
   const [showAddForm, setShowAddForm] = useState(false);
-  const [addForm, setAddForm] = useState({ full_name: '', email: '', phone: '' });
+  const [editingWorker, setEditingWorker] = useState(null);
+  const [addForm, setAddForm] = useState(EMPTY_WORKER_FORM);
   const [addResult, setAddResult] = useState(null);
   const [addError, setAddError] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -96,6 +99,14 @@ const MessManagerDashboard = () => {
     setAddError('');
   };
 
+  const resetWorkerForm = useCallback(() => {
+    setShowAddForm(false);
+    setEditingWorker(null);
+    setAddForm(EMPTY_WORKER_FORM);
+    setAddResult(null);
+    setAddError('');
+  }, []);
+
   const refreshWorkers = useCallback(
     async () => queryClient.invalidateQueries({ queryKey: MESS_MANAGER_WORKERS_QUERY_KEY }),
     [queryClient]
@@ -105,22 +116,43 @@ const MessManagerDashboard = () => {
     event.preventDefault();
     setSubmitting(true);
     setAddError('');
-    setAddResult(null);
+    if (!editingWorker) {
+      setAddResult(null);
+    }
 
     try {
-      const { data } = await api.post('/manager/mess-workers/', addForm);
-      setAddResult(data);
-      setAddForm({ full_name: '', email: '', phone: '' });
+      if (editingWorker) {
+        await api.patch(`/manager/mess-workers/${editingWorker.id}/`, addForm);
+        resetWorkerForm();
+      } else {
+        const { data } = await api.post('/manager/mess-workers/', addForm);
+        setAddResult(data);
+        setAddForm(EMPTY_WORKER_FORM);
+      }
       await refreshWorkers();
     } catch (error) {
       setAddError(
         error.response?.data?.detail ||
           error.response?.data?.email?.[0] ||
-          'Unable to create worker.'
+          error.response?.data?.full_name?.[0] ||
+          error.response?.data?.phone?.[0] ||
+          'Unable to save worker.'
       );
     } finally {
       setSubmitting(false);
     }
+  };
+
+  const handleEditWorker = (worker) => {
+    setEditingWorker(worker);
+    setAddForm({
+      full_name: worker.full_name || '',
+      email: worker.email || '',
+      phone: worker.phone || '',
+    });
+    setAddResult(null);
+    setAddError('');
+    setShowAddForm(true);
   };
 
   const handleToggle = async (userId) => {
@@ -188,8 +220,7 @@ const MessManagerDashboard = () => {
     }
 
     setActiveTab(item.id);
-    setAddResult(null);
-    setAddError('');
+    resetWorkerForm();
   };
 
   const handleRefresh = useCallback(async () => {
@@ -358,9 +389,15 @@ const MessManagerDashboard = () => {
                 <h1 style={{ fontSize: 24, fontWeight: 700 }}>Manage Workers</h1>
                 <button
                   onClick={() => {
-                    setShowAddForm(!showAddForm);
-                    setAddResult(null);
-                    setAddError('');
+                    if (showAddForm) {
+                      resetWorkerForm();
+                    } else {
+                      setEditingWorker(null);
+                      setAddForm(EMPTY_WORKER_FORM);
+                      setAddResult(null);
+                      setAddError('');
+                      setShowAddForm(true);
+                    }
                   }}
                   style={{
                     padding: '10px 20px',
@@ -398,7 +435,9 @@ const MessManagerDashboard = () => {
                     marginBottom: 24,
                   }}
                 >
-                  <h3 style={{ fontSize: 16, fontWeight: 600, marginBottom: 16 }}>New Worker</h3>
+                  <h3 style={{ fontSize: 16, fontWeight: 600, marginBottom: 16 }}>
+                    {editingWorker ? 'Edit Worker' : 'New Worker'}
+                  </h3>
                   <form
                     onSubmit={handleAddWorker}
                     noValidate
@@ -463,7 +502,13 @@ const MessManagerDashboard = () => {
                         opacity: submitting ? 0.6 : 1,
                       }}
                     >
-                      {submitting ? 'Creating...' : 'Create Worker'}
+                      {submitting
+                        ? editingWorker
+                          ? 'Saving...'
+                          : 'Creating...'
+                        : editingWorker
+                          ? 'Save Changes'
+                          : 'Create Worker'}
                     </button>
                   </form>
 
@@ -483,7 +528,7 @@ const MessManagerDashboard = () => {
                     </div>
                   ) : null}
 
-                  {addResult ? (
+                  {addResult && !editingWorker ? (
                     <div
                       style={{
                         marginTop: 12,
@@ -576,6 +621,24 @@ const MessManagerDashboard = () => {
                         </p>
                       </div>
                       <div style={{ display: 'flex', gap: 8 }}>
+                        <button
+                          onClick={() => handleEditWorker(worker)}
+                          title="Edit"
+                          style={{
+                            width: 36,
+                            height: 36,
+                            background: '#2a2a2a',
+                            border: '1px solid #444',
+                            borderRadius: 8,
+                            color: '#66aaff',
+                            cursor: 'pointer',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                          }}
+                        >
+                          <Pencil size={16} />
+                        </button>
                         <button
                           onClick={() => handleToggle(worker.id)}
                           title={worker.is_active ? 'Freeze' : 'Activate'}


### PR DESCRIPTION
## Summary
- add a scoped mess-worker update endpoint so mess managers can edit worker name, email, and phone without deleting the account
- add an edit action to the mess manager dashboard and reuse the worker form for both create and edit flows
- cover the new API with tests for successful updates, duplicate-email rejection, and cross-mess protection

## Root Cause
Mess worker management only supported list/create and freeze/delete actions. There was no update API and no edit control in the dashboard, so managers had to delete and recreate workers whenever contact details changed.

## Validation
- `docker exec upside_dine_backend sh -lc "cd /tmp/backend_issue30 && python manage.py test apps.users.tests"`
- `docker exec upside_dine_frontend sh -lc "ln -sfn /app/node_modules /tmp/frontend_issue30/node_modules && cd /tmp/frontend_issue30 && npm run build"`
- live browser test on `http://localhost:48080/manager/mess` confirming the new `Edit` action updates worker details and refreshes the list
