### PR TITLE
fix: issue 4 - reset crowd feed numbering after deletion

### DIFF
--- a/backend/apps/crowd/serializers.py
+++ b/backend/apps/crowd/serializers.py
@@ -5,6 +5,7 @@ from .models import CameraFeed, CrowdMetric
 
 class CameraFeedSerializer(serializers.ModelSerializer):
     mess_name = serializers.SerializerMethodField()
+    feed_number = serializers.SerializerMethodField()
 
     def get_mess_name(self, obj):
         from apps.mess.models import Mess
@@ -13,10 +14,34 @@ class CameraFeedSerializer(serializers.ModelSerializer):
         except Mess.DoesNotExist:
             return f"Mess {obj.mess_id}"
 
+    def get_feed_number(self, obj):
+        feed_number_map = self.context.get("feed_number_map") or {}
+        if obj.id in feed_number_map:
+            return feed_number_map[obj.id]
+
+        ordered_feed_ids = list(
+            CameraFeed.objects.filter(mess_id=obj.mess_id)
+            .order_by("created_at", "id")
+            .values_list("id", flat=True)
+        )
+        try:
+            return ordered_feed_ids.index(obj.id) + 1
+        except ValueError:
+            return None
+
     class Meta:
         model = CameraFeed
-        fields = ["id", "mess_id", "mess_name", "camera_url", "is_active", "location_description", "created_at"]
-        read_only_fields = ["id", "created_at"]
+        fields = [
+            "id",
+            "feed_number",
+            "mess_id",
+            "mess_name",
+            "camera_url",
+            "is_active",
+            "location_description",
+            "created_at",
+        ]
+        read_only_fields = ["id", "feed_number", "created_at"]
 
 
 class CrowdMetricSerializer(serializers.ModelSerializer):

--- a/backend/apps/crowd/tests.py
+++ b/backend/apps/crowd/tests.py
@@ -1,0 +1,72 @@
+from rest_framework.test import APITestCase
+
+from apps.crowd.models import CameraFeed
+from apps.mess.models import Mess
+from apps.users.models import Role, User
+
+
+class CameraFeedApiTests(APITestCase):
+    def setUp(self):
+        self.mess_manager_role = Role.objects.create(role_name="mess_manager")
+        self.manager = User.objects.create_user(
+            email="crowd.manager@example.com",
+            password="password123",
+            role=self.mess_manager_role,
+            is_active=True,
+            is_verified=True,
+        )
+        self.client.force_authenticate(user=self.manager)
+
+        self.hall_one = Mess.objects.create(hall_name="Hall 1", location="North")
+        self.hall_two = Mess.objects.create(hall_name="Hall 2", location="South")
+
+    def test_feed_list_numbers_feeds_sequentially_per_mess(self):
+        first_feed = CameraFeed.objects.create(
+            mess_id=self.hall_one.id,
+            camera_url="https://example.com/feed-1",
+            location_description="North Gate",
+        )
+        second_feed = CameraFeed.objects.create(
+            mess_id=self.hall_one.id,
+            camera_url="https://example.com/feed-2",
+            location_description="Dining Hall",
+        )
+        other_mess_feed = CameraFeed.objects.create(
+            mess_id=self.hall_two.id,
+            camera_url="https://example.com/feed-3",
+            location_description="Lobby",
+        )
+
+        response = self.client.get("/api/crowd/feeds/")
+
+        self.assertEqual(response.status_code, 200)
+
+        numbers_by_feed_id = {
+            item["id"]: item["feed_number"]
+            for item in response.data
+        }
+
+        self.assertEqual(numbers_by_feed_id[first_feed.id], 1)
+        self.assertEqual(numbers_by_feed_id[second_feed.id], 2)
+        self.assertEqual(numbers_by_feed_id[other_mess_feed.id], 1)
+
+    def test_new_feed_uses_first_display_number_after_previous_feed_is_deleted(self):
+        original_feed = CameraFeed.objects.create(
+            mess_id=self.hall_one.id,
+            camera_url="https://example.com/original-feed",
+            location_description="Main Entry",
+        )
+        original_feed.delete()
+
+        replacement_feed = CameraFeed.objects.create(
+            mess_id=self.hall_one.id,
+            camera_url="https://example.com/replacement-feed",
+            location_description="Main Entry",
+        )
+
+        response = self.client.get("/api/crowd/feeds/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["id"], replacement_feed.id)
+        self.assertEqual(response.data[0]["feed_number"], 1)

--- a/backend/apps/crowd/views.py
+++ b/backend/apps/crowd/views.py
@@ -59,7 +59,20 @@ class CameraFeedListCreateView(ListCreateAPIView):
     Only superadmin, mess managers, and canteen managers can access."""
     permission_classes = [FeedManagePermission]
     serializer_class = CameraFeedSerializer
-    queryset = CameraFeed.objects.all()
+    queryset = CameraFeed.objects.order_by("mess_id", "created_at", "id")
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        feeds = list(self.get_queryset())
+        feed_number_map = {}
+        counts_by_mess = {}
+
+        for feed in feeds:
+            counts_by_mess[feed.mess_id] = counts_by_mess.get(feed.mess_id, 0) + 1
+            feed_number_map[feed.id] = counts_by_mess[feed.mess_id]
+
+        context["feed_number_map"] = feed_number_map
+        return context
 
     def perform_create(self, serializer):
         serializer.save()
@@ -71,7 +84,7 @@ class CameraFeedDetailView(RetrieveUpdateDestroyAPIView):
     Only superadmin, mess managers, and canteen managers can access."""
     permission_classes = [FeedManagePermission]
     serializer_class = CameraFeedSerializer
-    queryset = CameraFeed.objects.all()
+    queryset = CameraFeed.objects.order_by("mess_id", "created_at", "id")
 
     def perform_update(self, serializer):
         serializer.save()

--- a/frontend/src/features/ml/components/CameraFeedStatus.jsx
+++ b/frontend/src/features/ml/components/CameraFeedStatus.jsx
@@ -61,7 +61,22 @@ export default function CameraFeedStatus({ filterMessId, messesList = [] }) {
     );
   }
 
-  const feeds = filterMessId ? allFeeds.filter(f => f.mess_id === Number(filterMessId)) : allFeeds;
+  const feeds = React.useMemo(() => {
+    const scopedFeeds = filterMessId
+      ? allFeeds.filter((feed) => feed.mess_id === Number(filterMessId))
+      : allFeeds;
+
+    return [...scopedFeeds].sort((left, right) => {
+      const messDelta = Number(left.mess_id) - Number(right.mess_id);
+      if (messDelta !== 0) return messDelta;
+
+      const feedNumberDelta =
+        Number(left.feed_number ?? left.id) - Number(right.feed_number ?? right.id);
+      if (feedNumberDelta !== 0) return feedNumberDelta;
+
+      return Number(left.id) - Number(right.id);
+    });
+  }, [allFeeds, filterMessId]);
 
   if (!feeds.length) {
     return (
@@ -113,7 +128,7 @@ export default function CameraFeedStatus({ filterMessId, messesList = [] }) {
                 {isActive ? 'Active' : 'Offline'}
               </div>
             </div>
-            <div className="camera-feed-card__title">Feed #{feed.id}</div>
+            <div className="camera-feed-card__title">Feed #{feed.feed_number ?? idx + 1}</div>
             {editingId === feed.id ? (
               <div style={{ marginTop: 8, marginBottom: 8 }}>
                 <input 

--- a/frontend/src/features/ml/components/CameraFeedStatus.jsx
+++ b/frontend/src/features/ml/components/CameraFeedStatus.jsx
@@ -61,22 +61,20 @@ export default function CameraFeedStatus({ filterMessId, messesList = [] }) {
     );
   }
 
-  const feeds = React.useMemo(() => {
-    const scopedFeeds = filterMessId
-      ? allFeeds.filter((feed) => feed.mess_id === Number(filterMessId))
-      : allFeeds;
+  const scopedFeeds = filterMessId
+    ? allFeeds.filter((feed) => feed.mess_id === Number(filterMessId))
+    : allFeeds;
 
-    return [...scopedFeeds].sort((left, right) => {
-      const messDelta = Number(left.mess_id) - Number(right.mess_id);
-      if (messDelta !== 0) return messDelta;
+  const feeds = [...scopedFeeds].sort((left, right) => {
+    const messDelta = Number(left.mess_id) - Number(right.mess_id);
+    if (messDelta !== 0) return messDelta;
 
-      const feedNumberDelta =
-        Number(left.feed_number ?? left.id) - Number(right.feed_number ?? right.id);
-      if (feedNumberDelta !== 0) return feedNumberDelta;
+    const feedNumberDelta =
+      Number(left.feed_number ?? left.id) - Number(right.feed_number ?? right.id);
+    if (feedNumberDelta !== 0) return feedNumberDelta;
 
-      return Number(left.id) - Number(right.id);
-    });
-  }, [allFeeds, filterMessId]);
+    return Number(left.id) - Number(right.id);
+  });
 
   if (!feeds.length) {
     return (


### PR DESCRIPTION
## Summary
- stop showing raw database ids as camera feed numbers in the crowd monitoring UI
- add a per-mess `feed_number` field in the crowd feed API so numbering stays sequential after deletes
- render feed cards using the stable display number and cover the delete-then-add regression with backend tests

## Root Cause
Camera feed cards were labeled with `feed.id`, which is a database primary key. After a feed was deleted, the next created row got a higher id, so the UI showed `Feed #2` instead of reusing `Feed #1`.

## Testing
- `docker exec upside_dine_backend sh -lc "cd /tmp/backend_issue4 && python manage.py test apps.crowd.tests"`
- `docker exec upside_dine_frontend sh -lc "ln -sfn /app/node_modules /tmp/frontend_issue4/node_modules && cd /tmp/frontend_issue4 && npm run build"`
