### PR TITLE
fix: issue 21 - canteen manager can add new items

### DIFF
--- a/backend/apps/canteen/tests.py
+++ b/backend/apps/canteen/tests.py
@@ -1,6 +1,11 @@
+from decimal import Decimal
+
 from django.test import TestCase
+from rest_framework.test import APITestCase
 
 from .models import Canteen
+from apps.users.models import Role, Staff, User
+from .models import CanteenMenuCategory, CanteenMenuItem
 
 
 class CanteenModelSmokeTests(TestCase):
@@ -8,7 +13,75 @@ class CanteenModelSmokeTests(TestCase):
         canteen = Canteen.objects.create(
             name="Hall 2 Canteen",
             location="Hall 2",
-            opening_time="08:00",
-            closing_time="22:00",
         )
         self.assertEqual(canteen.name, "Hall 2 Canteen")
+
+
+class CanteenManagerMenuApiTests(APITestCase):
+    def setUp(self):
+        self.canteen = Canteen.objects.create(name="Issue 21 Canteen", location="Hall 21")
+        self.manager_role = Role.objects.create(role_name="canteen_manager")
+        self.manager = User.objects.create_user(
+            email="issue21.manager@iitk.ac.in",
+            password="password123",
+            role=self.manager_role,
+            is_active=True,
+            is_verified=True,
+        )
+        Staff.objects.create(
+            user=self.manager,
+            full_name="Issue 21 Manager",
+            employee_code="ISSUE21MGR",
+            canteen=self.canteen,
+        )
+        self.client.force_authenticate(user=self.manager)
+
+    def test_manager_can_add_menu_item_using_named_category(self):
+        response = self.client.post(
+            "/api/canteen-manager/menu/",
+            {
+                "item_name": "Cheese Toast",
+                "description": "Toast with cheese",
+                "price": "55.00",
+                "category": "snacks",
+                "is_veg": True,
+                "preparation_time_mins": 10,
+                "is_available": True,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data["category_name"], "Snacks")
+
+        menu_item = CanteenMenuItem.objects.get(item_name="Cheese Toast")
+        self.assertEqual(menu_item.canteen_id, self.canteen.id)
+        self.assertEqual(menu_item.category.category_name, "Snacks")
+
+    def test_manager_can_update_menu_item_using_named_category(self):
+        original_category = CanteenMenuCategory.objects.create(
+            canteen=self.canteen,
+            category_name="Snacks",
+            display_order=1,
+        )
+        menu_item = CanteenMenuItem.objects.create(
+            canteen=self.canteen,
+            category=original_category,
+            item_name="Cold Coffee",
+            description="Iced coffee",
+            price=Decimal("65.00"),
+            preparation_time_mins=8,
+            is_veg=True,
+            is_available=True,
+        )
+
+        response = self.client.patch(
+            f"/api/canteen-manager/menu/{menu_item.id}/",
+            {"category": "beverages"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        menu_item.refresh_from_db()
+        self.assertEqual(menu_item.category.category_name, "Beverages")
+        self.assertEqual(response.data["category_name"], "Beverages")

--- a/backend/apps/canteen/views.py
+++ b/backend/apps/canteen/views.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from django.db.models import Count, Q, Sum
+from django.db.models import Count, Max, Q, Sum
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.generics import (
@@ -46,6 +46,54 @@ def _get_manager_canteens(user):
     if not canteen_id:
         return Canteen.objects.none()
     return Canteen.objects.filter(id=canteen_id)
+
+
+def _normalize_category_name(value):
+    return " ".join(str(value or "").split())
+
+
+def _coerce_menu_category_input(data, canteen):
+    if "category" not in data:
+        return data
+
+    raw_category = data.get("category")
+    if raw_category in (None, ""):
+        data["category"] = None
+        return data
+
+    if not isinstance(raw_category, str):
+        return data
+
+    normalized_category = _normalize_category_name(raw_category)
+    if not normalized_category:
+        data["category"] = None
+        return data
+
+    if normalized_category.isdigit():
+        data["category"] = int(normalized_category)
+        return data
+
+    existing_category = CanteenMenuCategory.objects.filter(
+        canteen=canteen,
+        category_name__iexact=normalized_category,
+    ).first()
+    if existing_category:
+        data["category"] = existing_category.id
+        return data
+
+    max_display_order = (
+        CanteenMenuCategory.objects.filter(canteen=canteen).aggregate(max_display_order=Max("display_order"))[
+            "max_display_order"
+        ]
+        or 0
+    )
+    category = CanteenMenuCategory.objects.create(
+        canteen=canteen,
+        category_name=normalized_category.title(),
+        display_order=max_display_order + 1,
+    )
+    data["category"] = category.id
+    return data
 
 
 class CanteenListView(ListAPIView):
@@ -122,6 +170,7 @@ class CanteenManagerMenuListCreateView(ListCreateAPIView):
 
     def create(self, request, *args, **kwargs):
         data = request.data.copy()
+        canteen = None
         if not request.user.is_superuser:
             canteen = _get_manager_canteens(request.user).first()
             if not canteen:
@@ -130,6 +179,12 @@ class CanteenManagerMenuListCreateView(ListCreateAPIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             data["canteen"] = canteen.id
+        else:
+            canteen = Canteen.objects.filter(id=data.get("canteen")).first()
+
+        if canteen:
+            data = _coerce_menu_category_input(data, canteen)
+
         serializer = self.get_serializer(data=data)
         serializer.is_valid(raise_exception=True)
 
@@ -155,7 +210,13 @@ class CanteenManagerMenuDetailView(RetrieveUpdateDestroyAPIView):
 
     def patch(self, request, *args, **kwargs):
         item = self.get_object()
-        serializer = self.get_serializer(item, data=request.data, partial=True)
+        data = request.data.copy()
+        target_canteen = item.canteen
+        if request.user.is_superuser and data.get("canteen"):
+            target_canteen = Canteen.objects.filter(id=data.get("canteen")).first() or item.canteen
+
+        data = _coerce_menu_category_input(data, target_canteen)
+        serializer = self.get_serializer(item, data=data, partial=True)
         serializer.is_valid(raise_exception=True)
 
         next_canteen = serializer.validated_data.get("canteen", item.canteen)

--- a/frontend/src/features/canteen/pages/ManagerMenuPage.jsx
+++ b/frontend/src/features/canteen/pages/ManagerMenuPage.jsx
@@ -12,6 +12,17 @@ import {
 } from '../../../lib/formValidation';
 import '../canteen.css';
 
+const CATEGORY_OPTIONS = ['snacks', 'beverages', 'meals', 'desserts'];
+
+const normalizeCategorySelection = (item) => {
+  const categoryValue =
+    item?.category_name ||
+    item?._categoryName ||
+    '';
+  const normalizedCategory = categoryValue.trim().toLowerCase();
+  return CATEGORY_OPTIONS.includes(normalizedCategory) ? normalizedCategory : 'snacks';
+};
+
 export default function ManagerMenuPage() {
   const navigate = useNavigate();
   const { menuItems = [], isLoading, addItem, updateItem, deleteItem } = useManagerMenu();
@@ -54,7 +65,15 @@ export default function ManagerMenuPage() {
   const startEdit = (item) => {
     shouldScrollToFormRef.current = true;
     setEditing(item.id);
-    setFormData({ item_name: item.item_name, description: item.description || '', price: String(item.price), category: item.category || 'snacks', is_veg: item.is_veg, preparation_time_mins: item.preparation_time_mins || 10, is_available: item.is_available });
+    setFormData({
+      item_name: item.item_name,
+      description: item.description || '',
+      price: String(item.price),
+      category: normalizeCategorySelection(item),
+      is_veg: item.is_veg,
+      preparation_time_mins: item.preparation_time_mins || 10,
+      is_available: item.is_available,
+    });
     setShowForm(true);
   };
 


### PR DESCRIPTION
## Summary
- let canteen manager menu requests accept category names like `snacks` and map them to real canteen categories
- create the category automatically for that canteen when the manager uses a new category name from the existing UI
- keep the manager edit form aligned with category names so add and edit both use consistent values
- refresh the canteen tests with regression coverage for named-category create and update flows

## Root Cause
The canteen manager UI submitted category values such as `snacks`, `beverages`, and `meals`, but the backend `category` field expects a numeric foreign-key id. That mismatch made add-item requests fail validation with `Incorrect type. Expected pk value, received str.` before the item could be created.

## Testing
- `docker exec upside_dine_backend sh -lc "cd /tmp/backend_issue21 && python manage.py test apps.canteen.tests.CanteenModelSmokeTests apps.canteen.tests.CanteenManagerMenuApiTests"`
- `docker exec upside_dine_frontend sh -lc "ln -sfn /app/node_modules /tmp/frontend_issue21/node_modules && cd /tmp/frontend_issue21 && npm run build"`
- live API verification on `http://localhost:48080/api/canteen-manager/menu/`
  - posted `category: "snacks"`
  - confirmed `201` response with `category_name: "Snacks"`
- live browser verification on `http://localhost:48080/manager/canteen/menu`
  - opened the canteen manager add-item form
  - created `Issue 21 Browser Item`
  - confirmed the new item appeared immediately and was saved under category `Beverages`
