### PR TITLE
fix: issue 45 - refresh student order tracking status

### DIFF
--- a/frontend/src/features/canteen/hooks/useOrderDetail.js
+++ b/frontend/src/features/canteen/hooks/useOrderDetail.js
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import api from "../../../lib/api";
 
+const TERMINAL_ORDER_STATUSES = new Set(["picked_up", "delivered", "cancelled", "rejected"]);
+
 export const useOrderDetail = (id) => {
   return useQuery({
     queryKey: ["order", id],
@@ -9,5 +11,14 @@ export const useOrderDetail = (id) => {
       return res.data;
     },
     enabled: !!id,
+    staleTime: 0,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status && TERMINAL_ORDER_STATUSES.has(status) ? false : 5000;
+    },
+    refetchIntervalInBackground: true,
   });
 };

--- a/frontend/src/features/canteen/hooks/useOrderHistory.js
+++ b/frontend/src/features/canteen/hooks/useOrderHistory.js
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import api from "../../../lib/api";
 
+const TERMINAL_ORDER_STATUSES = new Set(["picked_up", "delivered", "cancelled", "rejected"]);
+
 export const useOrderHistory = () => {
   return useQuery({
     queryKey: ["orders"],
@@ -8,5 +10,15 @@ export const useOrderHistory = () => {
       const res = await api.get("/orders/");
       return res.data;
     },
+    staleTime: 0,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchInterval: (query) => {
+      const orders = query.state.data;
+      const normalizedOrders = Array.isArray(orders) ? orders : orders?.results || [];
+      return normalizedOrders.some((order) => !TERMINAL_ORDER_STATUSES.has(order?.status)) ? 5000 : false;
+    },
+    refetchIntervalInBackground: true,
   });
 };


### PR DESCRIPTION
## Summary
- refetch student order detail immediately when the tracking page opens
- keep active student orders and the order history polling until they reach a terminal state
- stop polling once an order is delivered, picked up, cancelled, or rejected

## Testing
- npm run build
- live browser verification on http://localhost:48080/orders/2 by changing the backend order from pending to out_for_delivery while the page stayed open