### PR TITLE
fix: issue 3 - weekly extras edit day validation

### DIFF
--- a/backend/apps/mess/serializers.py
+++ b/backend/apps/mess/serializers.py
@@ -106,6 +106,39 @@ class MessMenuItemCreateUpdateSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("Item name cannot be blank.")
         return value
 
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+
+        instance = getattr(self, "instance", None)
+        mess = attrs.get("mess") or getattr(instance, "mess", None)
+        item_name = attrs.get("item_name") or getattr(instance, "item_name", None)
+        meal_type = attrs.get("meal_type") or getattr(instance, "meal_type", None)
+        day_of_week = attrs.get("day_of_week") or getattr(instance, "day_of_week", None)
+
+        if not all([mess, item_name, meal_type, day_of_week]):
+            return attrs
+
+        conflicting_items = MessMenuItem.objects.filter(
+            mess=mess,
+            item_name=item_name,
+            meal_type=meal_type,
+            day_of_week=day_of_week,
+        )
+        if instance is not None:
+            conflicting_items = conflicting_items.exclude(pk=instance.pk)
+
+        if conflicting_items.exists():
+            raise serializers.ValidationError(
+                {
+                    "detail": (
+                        f'An extra named "{item_name}" already exists for '
+                        f"{day_of_week.replace('_', ' ').title()} {meal_type}."
+                    )
+                }
+            )
+
+        return attrs
+
 
 class MessBookingCreateSerializer(serializers.Serializer):
     menu_item = serializers.PrimaryKeyRelatedField(queryset=MessMenuItem.objects.select_related("mess").all())

--- a/backend/apps/mess/tests/test_manager_api.py
+++ b/backend/apps/mess/tests/test_manager_api.py
@@ -269,6 +269,39 @@ class MessManagerAPITests(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_manager_patch_menu_item_rejects_duplicate_day_meal_name(self):
+        conflict_day = (
+            MessMenuItem.DayOfWeek.THURSDAY
+            if self.current_day != MessMenuItem.DayOfWeek.THURSDAY
+            else MessMenuItem.DayOfWeek.MONDAY
+        )
+        conflicting_item = MessMenuItem.objects.create(
+            mess=self.mess,
+            item_name=self.menu_item.item_name,
+            description="Conflict item",
+            price=Decimal("45.00"),
+            meal_type=self.menu_item.meal_type,
+            day_of_week=conflict_day,
+            available_quantity=120,
+            default_quantity=120,
+            is_active=True,
+        )
+
+        self._auth_manager()
+        response = self.client.patch(
+            f"/api/mess/manager/menu/{self.menu_item.id}/",
+            {"day_of_week": conflicting_item.day_of_week},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data["detail"][0],
+            f'An extra named "Paneer Roll" already exists for {conflict_day.title()} lunch.',
+        )
+        self.menu_item.refresh_from_db()
+        self.assertEqual(self.menu_item.day_of_week, self.current_day)
+
     def test_manager_delete_menu_item_soft_deletes(self):
         self._auth_manager()
         response = self.client.delete(f"/api/mess/manager/menu/{self.menu_item.id}/")


### PR DESCRIPTION
## Summary
- validate mess weekly extras edits before saving so duplicate day and meal combinations do not hit the database constraint
- return a clean 400 validation message instead of a raw HTML 500 page when a manager moves an item onto an occupied day
- add a regression test for editing an extra onto a conflicting day

## Testing
- docker exec upside_dine_backend sh -lc "cd /tmp/backend_issue3 && python manage.py test apps.mess.tests.test_manager_api.MessManagerAPITests.test_manager_patch_menu_item_rejects_duplicate_day_meal_name"
- live browser verification on http://localhost:48080/manager/mess/menu by editing the Monday Issue 3 Paneer item to Thursday and confirming the modal shows the validation message instead of crashing
