### PR TITLE
fix: issue 33 - adding OTP error

### DIFF
--- a/backend/apps/orders/tests.py
+++ b/backend/apps/orders/tests.py
@@ -1,8 +1,13 @@
+from decimal import Decimal
+
 from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APITestCase
 
 from apps.canteen.models import Canteen, CanteenMenuItem
-from apps.users.models import Role, Student, User
+from apps.users.models import Role, Staff, Student, User
 
+from .models import CanteenOrder, CanteenOrderItem
 from .services import create_order_for_student
 
 
@@ -40,3 +45,78 @@ class OrderServiceSmokeTests(TestCase):
         )
         self.assertEqual(order.total_amount, order.subtotal)
         self.assertEqual(order.items.count(), 1)
+
+
+class CanteenManagerPickupVerificationApiTests(APITestCase):
+    def setUp(self):
+        self.manager_role = Role.objects.create(role_name="canteen_manager")
+        self.student_role = Role.objects.create(role_name="student")
+        self.canteen = Canteen.objects.create(
+            name="Issue 33 Canteen",
+            location="Hall 33",
+        )
+        self.manager = User.objects.create_user(
+            email="issue33.manager@example.com",
+            password="password123",
+            role=self.manager_role,
+            is_active=True,
+            is_verified=True,
+        )
+        Staff.objects.create(
+            user=self.manager,
+            full_name="Issue 33 Manager",
+            employee_code="ISSUE33MGR",
+            canteen=self.canteen,
+        )
+
+        self.student_user = User.objects.create_user(
+            email="issue33.student@iitk.ac.in",
+            password="password123",
+            role=self.student_role,
+            is_active=True,
+            is_verified=True,
+        )
+        self.student = Student.objects.create(
+            user=self.student_user,
+            roll_number="ISSUE33",
+            full_name="Issue 33 Student",
+        )
+        self.item = CanteenMenuItem.objects.create(
+            canteen=self.canteen,
+            item_name="Issue 33 Item",
+            price=Decimal("40.00"),
+            preparation_time_mins=10,
+            available_quantity=10,
+            is_veg=True,
+            is_available=True,
+        )
+        self.order = CanteenOrder.objects.create(
+            order_number="ISSUE33-VERIFY",
+            student=self.student,
+            canteen=self.canteen,
+            order_type=CanteenOrder.ORDER_TYPE_PICKUP,
+            subtotal=Decimal("40.00"),
+            delivery_fee=Decimal("0.00"),
+            total_amount=Decimal("40.00"),
+            status=CanteenOrder.STATUS_READY,
+            estimated_ready_time=timezone.now(),
+            pickup_otp="123456",
+        )
+        CanteenOrderItem.objects.create(
+            order=self.order,
+            menu_item=self.item,
+            quantity=1,
+            unit_price=Decimal("40.00"),
+            total_price=Decimal("40.00"),
+        )
+        self.client.force_authenticate(user=self.manager)
+
+    def test_invalid_pickup_otp_returns_field_error(self):
+        response = self.client.post(
+            f"/api/canteen-manager/orders/{self.order.id}/verify-pickup/",
+            {"pickup_otp": "000000"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["pickup_otp"], "Invalid pickup OTP.")

--- a/backend/apps/orders/views.py
+++ b/backend/apps/orders/views.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.utils import timezone
+from rest_framework.exceptions import ValidationError
 from rest_framework import status
 from rest_framework.generics import GenericAPIView, ListAPIView, RetrieveAPIView
 from rest_framework.permissions import BasePermission, IsAuthenticated
@@ -266,6 +267,8 @@ class CanteenManagerVerifyPickupView(GenericAPIView):
                 pickup_otp=serializer.validated_data.get("pickup_otp", ""),
                 pickup_qr_code=serializer.validated_data.get("pickup_qr_code", ""),
             )
+        except ValidationError as exc:
+            return Response(exc.detail, status=status.HTTP_400_BAD_REQUEST)
         except Exception as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         return Response(OrderStatusSerializer(order).data)


### PR DESCRIPTION
## What changed
- returned field-level OTP validation errors from the canteen pickup verification API instead of wrapping them in a generic `detail` string
- added a regression test covering an invalid pickup OTP for a canteen manager

## Why
The manager pickup flow showed a weird serialized error payload when the OTP was wrong, instead of a clean error message the UI could display directly.

## Validation
- python manage.py test apps.orders.tests.CanteenManagerPickupVerificationApiTests
- live browser verification on http://localhost:48080/manager/canteen/orders/3 with invalid OTP `000000`
