### PR TITLE
fix: issue 17 and issue 9 - admin manager controls and worker scanner back button

### DIFF
--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -527,11 +527,144 @@ class ManagerSerializer(serializers.ModelSerializer):
     employee_code = serializers.CharField(source='staff_profile.employee_code', read_only=True)
     canteen_id = serializers.IntegerField(source='staff_profile.canteen_id', read_only=True)
     role_name = serializers.CharField(source='role.role_name', read_only=True)
+    mess_id = serializers.SerializerMethodField()
+    assignment_name = serializers.SerializerMethodField()
 
     class Meta:
         model = User
-        fields = ['id', 'email', 'phone', 'full_name', 'employee_code', 'canteen_id', 'role_name', 'is_active', 'date_joined']
+        fields = [
+            'id',
+            'email',
+            'phone',
+            'full_name',
+            'employee_code',
+            'canteen_id',
+            'mess_id',
+            'assignment_name',
+            'role_name',
+            'is_active',
+            'date_joined',
+        ]
         read_only_fields = fields
+
+    def _get_manager_assignment(self, obj):
+        staff_profile = getattr(obj, "staff_profile", None)
+        if staff_profile is None:
+            return None
+
+        return (
+            staff_profile.mess_assignments.filter(assignment_role="manager", is_active=True)
+            .select_related("mess")
+            .order_by("-updated_at", "-created_at")
+            .first()
+        )
+
+    def get_mess_id(self, obj):
+        assignment = self._get_manager_assignment(obj)
+        return assignment.mess_id if assignment else None
+
+    def get_assignment_name(self, obj):
+        staff_profile = getattr(obj, "staff_profile", None)
+        role = getattr(getattr(obj, "role", None), "role_name", "")
+        if role == "canteen_manager":
+            return getattr(getattr(staff_profile, "canteen", None), "name", None)
+
+        assignment = self._get_manager_assignment(obj)
+        if assignment:
+            return assignment.mess.name
+        return None
+
+
+class UpdateManagerSerializer(serializers.Serializer):
+    """Serializer for admin managers to update canteen or mess managers."""
+
+    email = serializers.EmailField()
+    full_name = serializers.CharField(max_length=100)
+    phone = serializers.CharField(max_length=20)
+    role_name = serializers.ChoiceField(choices=['canteen_manager', 'mess_manager'])
+    canteen_id = serializers.IntegerField(required=False, allow_null=True)
+    mess_id = serializers.IntegerField(required=False, allow_null=True)
+
+    def validate_email(self, value):
+        value = value.lower()
+        conflicting_user = User.objects.filter(email=value)
+        if self.instance is not None:
+            conflicting_user = conflicting_user.exclude(pk=self.instance.pk)
+        if conflicting_user.exists():
+            raise serializers.ValidationError("User with this email already exists.")
+        return value
+
+    def validate(self, attrs):
+        role_name = attrs.get("role_name")
+        canteen_id = attrs.get("canteen_id")
+        mess_id = attrs.get("mess_id")
+
+        if role_name == "canteen_manager":
+            if not canteen_id:
+                raise serializers.ValidationError(
+                    {"canteen_id": "Canteen is required for canteen managers."}
+                )
+            from apps.canteen.models import Canteen
+
+            if not Canteen.objects.filter(id=canteen_id).exists():
+                raise serializers.ValidationError({"canteen_id": "Selected canteen does not exist."})
+        elif role_name == "mess_manager":
+            if not mess_id:
+                raise serializers.ValidationError(
+                    {"mess_id": "Mess is required for mess managers."}
+                )
+            if not Mess.objects.filter(id=mess_id).exists():
+                raise serializers.ValidationError({"mess_id": "Selected mess does not exist."})
+
+        return attrs
+
+    @transaction.atomic
+    def update(self, instance, validated_data):
+        role_name = validated_data["role_name"]
+        role, _ = Role.objects.get_or_create(role_name=role_name)
+        staff_profile = instance.staff_profile
+
+        instance.email = validated_data["email"]
+        instance.phone = validated_data["phone"]
+        instance.role = role
+        instance.save(update_fields=["email", "phone", "role"])
+
+        staff_profile.full_name = validated_data["full_name"]
+
+        manager_assignments = MessStaffAssignment.objects.filter(
+            staff=staff_profile,
+            assignment_role="manager",
+        )
+
+        if role_name == "canteen_manager":
+            from apps.canteen.models import Canteen
+
+            staff_profile.canteen = Canteen.objects.get(id=validated_data["canteen_id"])
+            staff_profile.is_mess_staff = False
+            manager_assignments.filter(is_active=True).update(is_active=False)
+        else:
+            selected_mess = Mess.objects.get(id=validated_data["mess_id"])
+            staff_profile.canteen = None
+            staff_profile.is_mess_staff = True
+
+            active_assignment = manager_assignments.filter(mess=selected_mess).first()
+            manager_assignments.exclude(
+                pk=getattr(active_assignment, "pk", None)
+            ).filter(is_active=True).update(is_active=False)
+            if active_assignment:
+                if not active_assignment.is_active:
+                    active_assignment.is_active = True
+                    active_assignment.save(update_fields=["is_active", "updated_at"])
+            else:
+                MessStaffAssignment.objects.create(
+                    staff=staff_profile,
+                    mess=selected_mess,
+                    assignment_role="manager",
+                    is_active=True,
+                )
+
+        staff_profile.save(update_fields=["full_name", "canteen", "is_mess_staff"])
+        return instance
 
 
 class CreateMessSerializer(serializers.Serializer):

--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -326,6 +326,136 @@ class MessWorkerManagementTests(APITestCase):
         self.assertEqual(response.status_code, 404)
 
 
+class AdminManagerManagementTests(APITestCase):
+    def setUp(self):
+        self.admin_role = Role.objects.create(role_name="admin_manager")
+        self.mess_manager_role = Role.objects.create(role_name="mess_manager")
+        self.canteen_manager_role = Role.objects.create(role_name="canteen_manager")
+
+        self.admin_user = User.objects.create_user(
+            email="admin.manager@example.com",
+            password="password123",
+            role=self.admin_role,
+            is_active=True,
+            is_verified=True,
+        )
+        self.client.force_authenticate(user=self.admin_user)
+
+        self.mess = Mess.objects.create(hall_name="Hall 1", location="North Block")
+        self.other_mess = Mess.objects.create(hall_name="Hall 2", location="South Block")
+        self.canteen = Canteen.objects.create(name="North Canteen", location="Hall 1")
+
+        self.manager = User.objects.create_user(
+            email="manager.one@example.com",
+            password="password123",
+            phone="9999999999",
+            role=self.mess_manager_role,
+            is_active=True,
+            is_verified=True,
+        )
+        self.manager_staff = Staff.objects.create(
+            user=self.manager,
+            full_name="Manager One",
+            employee_code="ADM001",
+            is_mess_staff=True,
+        )
+        MessStaffAssignment.objects.filter(staff=self.manager_staff).update(is_active=False)
+        MessStaffAssignment.objects.create(
+            staff=self.manager_staff,
+            mess=self.mess,
+            assignment_role="manager",
+            is_active=True,
+        )
+
+        self.duplicate_user = User.objects.create_user(
+            email="taken@example.com",
+            password="password123",
+            role=self.admin_role,
+            is_active=True,
+            is_verified=True,
+        )
+
+    def test_admin_can_update_manager_details_and_assignment(self):
+        response = self.client.put(
+            f"/api/admin/managers/{self.manager.id}/",
+            {
+                "full_name": "Updated Manager",
+                "email": "updated.manager@example.com",
+                "phone": "8888888888",
+                "role_name": "canteen_manager",
+                "canteen_id": self.canteen.id,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.manager.refresh_from_db()
+        self.manager_staff.refresh_from_db()
+        self.assertEqual(self.manager.email, "updated.manager@example.com")
+        self.assertEqual(self.manager.phone, "8888888888")
+        self.assertEqual(self.manager.role.role_name, "canteen_manager")
+        self.assertEqual(self.manager_staff.full_name, "Updated Manager")
+        self.assertEqual(self.manager_staff.canteen, self.canteen)
+        self.assertFalse(self.manager_staff.is_mess_staff)
+        self.assertFalse(
+            MessStaffAssignment.objects.filter(
+                staff=self.manager_staff,
+                assignment_role="manager",
+                is_active=True,
+            ).exists()
+        )
+        self.assertEqual(response.data["assignment_name"], self.canteen.name)
+        self.assertEqual(response.data["canteen_id"], self.canteen.id)
+        self.assertIsNone(response.data["mess_id"])
+
+    def test_admin_can_reassign_manager_to_another_mess(self):
+        response = self.client.put(
+            f"/api/admin/managers/{self.manager.id}/",
+            {
+                "full_name": "Manager One",
+                "email": "manager.one@example.com",
+                "phone": "9999999999",
+                "role_name": "mess_manager",
+                "mess_id": self.other_mess.id,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        active_assignment = MessStaffAssignment.objects.get(
+            staff=self.manager_staff,
+            assignment_role="manager",
+            is_active=True,
+        )
+        self.assertEqual(active_assignment.mess, self.other_mess)
+        self.assertEqual(response.data["mess_id"], self.other_mess.id)
+        self.assertEqual(response.data["assignment_name"], self.other_mess.name)
+
+    def test_admin_update_rejects_duplicate_manager_email(self):
+        response = self.client.put(
+            f"/api/admin/managers/{self.manager.id}/",
+            {
+                "full_name": "Manager One",
+                "email": self.duplicate_user.email,
+                "phone": "9999999999",
+                "role_name": "mess_manager",
+                "mess_id": self.mess.id,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("email", response.data)
+        self.manager.refresh_from_db()
+        self.assertEqual(self.manager.email, "manager.one@example.com")
+
+    def test_admin_can_delete_manager(self):
+        response = self.client.delete(f"/api/admin/managers/{self.manager.id}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(User.objects.filter(id=self.manager.id).exists())
+
+
 class AdminMessManagementTests(APITestCase):
     def setUp(self):
         self.admin_role = Role.objects.create(role_name="admin_manager")

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -463,6 +463,27 @@ class ToggleManagerStatusView(GenericAPIView):
     """View for admin managers to activate/deactivate canteen/mess managers"""
     permission_classes = [IsAuthenticated]
 
+    def put(self, request, user_id):
+        """Update manager contact details or assignment."""
+        if not hasattr(request.user, 'role') or request.user.role.role_name != 'admin_manager':
+            return Response({"detail": "Only admin managers can manage managers."}, status=status.HTTP_403_FORBIDDEN)
+
+        try:
+            manager = User.objects.select_related('staff_profile', 'role').get(
+                id=user_id,
+                role__role_name__in=['canteen_manager', 'mess_manager']
+            )
+        except User.DoesNotExist:
+            return Response({"detail": "Manager not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        from .serializers import ManagerSerializer, UpdateManagerSerializer
+
+        serializer = UpdateManagerSerializer(instance=manager, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        manager = serializer.save()
+
+        return Response(ManagerSerializer(manager).data)
+
     def patch(self, request, user_id):
         """Toggle manager active status (freeze/unfreeze)"""
         # Check if user is admin manager

--- a/frontend/src/features/mess/pages/QRScannerPage.jsx
+++ b/frontend/src/features/mess/pages/QRScannerPage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Camera, History, Upload, LogOut, User } from 'lucide-react';
+import { ArrowLeft, Camera, History, Upload, LogOut, User } from 'lucide-react';
 import { useVerifyQR } from '../hooks/useVerifyQR';
 import VerificationResult from '../components/VerificationResult';
 import { FIELD_LIMITS, sanitizeUnstructuredText } from '../../../lib/formValidation';
@@ -182,6 +182,14 @@ const QRScannerPage = () => {
   return (
     <div className="mess-page">
       <div className="mess-page-header">
+        <button
+          type="button"
+          className="mess-back-btn"
+          onClick={() => navigate('/profile')}
+          aria-label="Go back"
+        >
+          <ArrowLeft size={18} />
+        </button>
         <h1 className="mess-page-title">QR Scanner</h1>
         <div style={{ marginLeft: 'auto', display: 'flex', gap: 10 }}>
           <div

--- a/frontend/src/pages/AdminManagerDashboard.jsx
+++ b/frontend/src/pages/AdminManagerDashboard.jsx
@@ -27,6 +27,14 @@ import { compareNaturalText } from '../lib/naturalSort';
 import PullToRefresh from '../components/PullToRefresh';
 import './AdminManagerDashboard.css';
 
+const INITIAL_MANAGER_FORM_DATA = {
+  email: '',
+  full_name: '',
+  phone: '',
+  role_name: 'mess_manager',
+  canteen_id: '',
+  mess_id: '',
+};
 const INITIAL_MESS_FORM_DATA = { hall_name: '', location: '' };
 
 const TAB_ITEMS = [
@@ -169,10 +177,12 @@ const EntitySectionSkeleton = ({ columns = 6 }) => (
 const DetailSheet = ({
   entity,
   onClose,
+  onEditManager,
   onEditMess,
   onToggleManager,
   onToggleMess,
   onToggleCanteen,
+  onDeleteManager,
   onDeleteMess,
   onDeleteCanteen,
 }) => {
@@ -197,6 +207,7 @@ const DetailSheet = ({
       { label: 'Email', value: item.email },
       { label: 'Phone', value: item.phone || 'Not set' },
       { label: 'Role', value: formatRoleLabel(item.role_name) },
+      { label: 'Assignment', value: item.assignment_name || 'Not assigned' },
       { label: 'Employee Code', value: item.employee_code || 'Not assigned' },
     ];
     primaryAction = {
@@ -206,6 +217,18 @@ const DetailSheet = ({
         : 'admin-action-button admin-action-button--success',
       onClick: () => onToggleManager(item.id, item.is_active),
       icon: ShieldCheck,
+    };
+    secondaryAction = {
+      label: 'Edit Manager',
+      className: 'admin-action-button',
+      onClick: () => onEditManager(item),
+      icon: Pencil,
+    };
+    tertiaryAction = {
+      label: 'Delete Manager',
+      className: 'admin-action-button admin-action-button--ghost',
+      onClick: () => onDeleteManager(item.id),
+      icon: Trash2,
     };
   }
 
@@ -347,14 +370,8 @@ const AdminManagerDashboard = () => {
   const [showAddMessForm, setShowAddMessForm] = useState(false);
   const [showAddCanteenForm, setShowAddCanteenForm] = useState(false);
   const [selectedEntity, setSelectedEntity] = useState(null);
-  const [formData, setFormData] = useState({
-    email: '',
-    full_name: '',
-    phone: '',
-    role_name: 'mess_manager',
-    canteen_id: '',
-    mess_id: '',
-  });
+  const [formData, setFormData] = useState(INITIAL_MANAGER_FORM_DATA);
+  const [editingManagerId, setEditingManagerId] = useState(null);
   const [messFormData, setMessFormData] = useState(INITIAL_MESS_FORM_DATA);
   const [editingMessId, setEditingMessId] = useState(null);
   const [canteenFormData, setCanteenFormData] = useState({ name: '', location: '' });
@@ -425,6 +442,8 @@ const AdminManagerDashboard = () => {
     setShowAddForm(false);
     setShowAddCanteenForm(false);
     setShowAddMessForm(false);
+    setEditingManagerId(null);
+    setFormData(INITIAL_MANAGER_FORM_DATA);
     setEditingMessId(null);
     setMessFormData(INITIAL_MESS_FORM_DATA);
   };
@@ -482,7 +501,52 @@ const AdminManagerDashboard = () => {
     setMessage({ type: '', text: '' });
   };
 
-  const handleAddManager = async (event) => {
+  const resetManagerForm = () => {
+    setFormData(INITIAL_MANAGER_FORM_DATA);
+    setEditingManagerId(null);
+    setShowAddForm(false);
+  };
+
+  const getManagerErrorMessage = (error, fallbackMessage) =>
+    error.response?.data?.email?.[0] ||
+    error.response?.data?.email ||
+    error.response?.data?.phone?.[0] ||
+    error.response?.data?.phone ||
+    error.response?.data?.full_name?.[0] ||
+    error.response?.data?.full_name ||
+    error.response?.data?.role_name?.[0] ||
+    error.response?.data?.role_name ||
+    error.response?.data?.canteen_id?.[0] ||
+    error.response?.data?.canteen_id ||
+    error.response?.data?.mess_id?.[0] ||
+    error.response?.data?.mess_id ||
+    error.response?.data?.detail ||
+    fallbackMessage;
+
+  const handleEditManager = (manager) => {
+    setSelectedEntity(null);
+    setMessage({ type: '', text: '' });
+    setEditingManagerId(manager.id);
+    setFormData({
+      email: manager.email || '',
+      full_name: manager.full_name || '',
+      phone: manager.phone || '',
+      role_name: manager.role_name || 'mess_manager',
+      canteen_id:
+        manager.role_name === 'canteen_manager' && manager.canteen_id
+          ? String(manager.canteen_id)
+          : '',
+      mess_id:
+        manager.role_name === 'mess_manager' && manager.mess_id
+          ? String(manager.mess_id)
+          : '',
+    });
+    setShowAddMessForm(false);
+    setShowAddCanteenForm(false);
+    setShowAddForm(true);
+  };
+
+  const handleSaveManager = async (event) => {
     event.preventDefault();
     setSubmittingType('manager');
     setMessage({ type: '', text: '' });
@@ -503,37 +567,26 @@ const AdminManagerDashboard = () => {
         payload.mess_id = parseInt(formData.mess_id, 10);
       }
 
-      const { data } = await api.post('/admin/managers/', payload);
+      const { data } = editingManagerId
+        ? await api.put(`/admin/managers/${editingManagerId}/`, payload)
+        : await api.post('/admin/managers/', payload);
       setMessage({
         type: 'success',
-        text: `Manager created. Email: ${data.email}, Employee Code: ${data.employee_code}.`,
+        text: editingManagerId
+          ? `Manager updated: ${data.full_name}.`
+          : `Manager created. Email: ${data.email}, Employee Code: ${data.employee_code}.`,
       });
-      setFormData({
-        email: '',
-        full_name: '',
-        phone: '',
-        role_name: 'mess_manager',
-        canteen_id: '',
-        mess_id: '',
-      });
-      setShowAddForm(false);
+      setSelectedEntity(null);
+      resetManagerForm();
       await refreshManagers();
     } catch (error) {
-      const data = error.response?.data;
-      let errorMessage = 'Unable to create manager.';
-
-      if (data) {
-        if (data.email) errorMessage = `Email error: ${data.email[0] || data.email}`;
-        else if (data.phone) errorMessage = `Phone error: ${data.phone[0] || data.phone}`;
-        else if (data.full_name) errorMessage = `Name error: ${data.full_name[0] || data.full_name}`;
-        else if (data.role_name) errorMessage = `Role error: ${data.role_name[0] || data.role_name}`;
-        else if (data.canteen_id) errorMessage = `Canteen error: ${data.canteen_id[0] || data.canteen_id}`;
-        else if (data.mess_id) errorMessage = `Mess error: ${data.mess_id[0] || data.mess_id}`;
-        else if (data.detail) errorMessage = data.detail;
-        else if (typeof data === 'string') errorMessage = data;
-      }
-
-      setMessage({ type: 'error', text: errorMessage });
+      setMessage({
+        type: 'error',
+        text: getManagerErrorMessage(
+          error,
+          editingManagerId ? 'Unable to update manager.' : 'Unable to create manager.'
+        ),
+      });
     } finally {
       setSubmittingType('');
     }
@@ -626,6 +679,24 @@ const AdminManagerDashboard = () => {
       });
     } catch {
       setMessage({ type: 'error', text: 'Unable to update manager status.' });
+    }
+  };
+
+  const handleDeleteManager = async (userId) => {
+    if (!window.confirm('Are you sure you want to delete this manager?')) {
+      return;
+    }
+
+    try {
+      await api.delete(`/admin/managers/${userId}/`);
+      setSelectedEntity(null);
+      if (editingManagerId === userId) {
+        resetManagerForm();
+      }
+      await refreshManagers();
+      setMessage({ type: 'success', text: 'Manager deleted successfully.' });
+    } catch {
+      setMessage({ type: 'error', text: 'Unable to delete manager.' });
     }
   };
 
@@ -726,7 +797,13 @@ const AdminManagerDashboard = () => {
     setMessage({ type: '', text: '' });
 
     if (activeTab === 'managers') {
-      setShowAddForm((current) => !current);
+      if (showAddForm) {
+        resetManagerForm();
+      } else {
+        setEditingManagerId(null);
+        setFormData(INITIAL_MANAGER_FORM_DATA);
+        setShowAddForm(true);
+      }
       setShowAddMessForm(false);
       setShowAddCanteenForm(false);
       return;
@@ -807,6 +884,13 @@ const AdminManagerDashboard = () => {
                       <div className="admin-action-row admin-action-row--desktop">
                         <button
                           type="button"
+                          className="admin-action-button"
+                          onClick={() => handleEditManager(manager)}
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
                           className={`admin-action-button ${
                             manager.is_active
                               ? 'admin-action-button--danger'
@@ -815,6 +899,13 @@ const AdminManagerDashboard = () => {
                           onClick={() => handleToggleStatus(manager.id, manager.is_active)}
                         >
                           {manager.is_active ? 'Freeze' : 'Activate'}
+                        </button>
+                        <button
+                          type="button"
+                          className="admin-action-button admin-action-button--ghost"
+                          onClick={() => handleDeleteManager(manager.id)}
+                        >
+                          Delete
                         </button>
                       </div>
                     </td>
@@ -1099,7 +1190,7 @@ const AdminManagerDashboard = () => {
 
             <section className="admin-panel">
               {activeTab === 'managers' && showAddForm ? (
-                <form className="admin-form-panel" onSubmit={handleAddManager} noValidate>
+                <form className="admin-form-panel" onSubmit={handleSaveManager} noValidate>
                   <div className="admin-form-grid">
                     <label className="admin-field">
                       <span>Full Name *</span>
@@ -1219,7 +1310,13 @@ const AdminManagerDashboard = () => {
                       className="admin-primary-button"
                       disabled={submittingType === 'manager'}
                     >
-                      {submittingType === 'manager' ? 'Creating...' : 'Create Manager'}
+                      {submittingType === 'manager'
+                        ? editingManagerId
+                          ? 'Saving...'
+                          : 'Creating...'
+                        : editingManagerId
+                        ? 'Save Changes'
+                        : 'Create Manager'}
                     </button>
                   </div>
                 </form>
@@ -1342,10 +1439,12 @@ const AdminManagerDashboard = () => {
         <DetailSheet
           entity={selectedEntity}
           onClose={() => setSelectedEntity(null)}
+          onEditManager={handleEditManager}
           onEditMess={handleEditMess}
           onToggleManager={handleToggleStatus}
           onToggleMess={handleToggleMess}
           onToggleCanteen={handleToggleCanteen}
+          onDeleteManager={handleDeleteManager}
           onDeleteMess={handleDeleteMess}
           onDeleteCanteen={handleDeleteCanteen}
         />


### PR DESCRIPTION
## What changed
- added full admin edit and delete controls for canteen and mess managers in the admin dashboard
- added the backend manager update endpoint and regression tests for admin-side manager edits
- added a visible back button to the worker QR scanner page

## Issue coverage
- fixes issue #17: admin dashboard can now edit and delete managers
- fixes issue #9: worker scanner page now has a back button
- issue #19 was verified on the latest `deployment_v4` code and is already fixed, so it is not part of this diff

## Validation
- python manage.py test apps.users.tests
- npm run build
- live browser verification on http://localhost:48080/manager/admin for manager edit + delete
- live browser verification on http://localhost:48080/worker/scan for back-button visibility and navigation to /profile
- live browser verification on http://localhost:48080/manager/canteen/orders confirming active/pending stats for issue #19 already exist
