### PR TITLE
fix: issue 2 - admin canteen freeze and delete actions

### DIFF
--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -509,3 +509,34 @@ class AdminMessManagementTests(APITestCase):
         mess.refresh_from_db()
         self.assertFalse(mess.is_active)
         self.assertEqual(response.data["is_active"], False)
+
+
+class AdminCanteenManagementTests(APITestCase):
+    def setUp(self):
+        self.admin_role = Role.objects.create(role_name="admin_manager")
+        self.admin_user = User.objects.create_user(
+            email="admin.canteen@example.com",
+            password="password123",
+            role=self.admin_role,
+            is_active=True,
+            is_verified=True,
+        )
+        self.client.force_authenticate(user=self.admin_user)
+
+    def test_admin_can_toggle_canteen_status(self):
+        canteen = Canteen.objects.create(name="Issue 2 Canteen", location="North Block")
+
+        response = self.client.patch(f"/api/admin/canteens/{canteen.id}/", {}, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        canteen.refresh_from_db()
+        self.assertFalse(canteen.is_active)
+        self.assertEqual(response.data["is_active"], False)
+
+    def test_admin_can_delete_canteen(self):
+        canteen = Canteen.objects.create(name="Issue 2 Delete Canteen", location="South Block")
+
+        response = self.client.delete(f"/api/admin/canteens/{canteen.id}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Canteen.objects.filter(id=canteen.id).exists())

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -656,26 +656,29 @@ class AdminCanteenDetailView(GenericAPIView):
     """View to toggle status or delete a canteen"""
     permission_classes = [IsAuthenticated]
 
-    def patch(self, request, canteen_id):
+    def _get_canteen(self, pk):
+        from apps.canteen.models import Canteen
+
+        return Canteen.objects.get(id=pk)
+
+    def patch(self, request, pk):
         if not hasattr(request.user, 'role') or request.user.role.role_name != 'admin_manager':
             return Response({"detail": "Only admin managers can access this."}, status=status.HTTP_403_FORBIDDEN)
-        
-        from apps.canteen.models import Canteen
+
         try:
-            canteen = Canteen.objects.get(id=canteen_id)
+            canteen = self._get_canteen(pk)
             canteen.is_active = not canteen.is_active
             canteen.save()
             return Response({"detail": f"Canteen {'activated' if canteen.is_active else 'frozen'} successfully.", "is_active": canteen.is_active})
         except Canteen.DoesNotExist:
             return Response({"detail": "Canteen not found."}, status=status.HTTP_404_NOT_FOUND)
 
-    def delete(self, request, canteen_id):
+    def delete(self, request, pk):
         if not hasattr(request.user, 'role') or request.user.role.role_name != 'admin_manager':
             return Response({"detail": "Only admin managers can access this."}, status=status.HTTP_403_FORBIDDEN)
-        
-        from apps.canteen.models import Canteen
+
         try:
-            canteen = Canteen.objects.get(id=canteen_id)
+            canteen = self._get_canteen(pk)
             canteen_name = canteen.name
             canteen.delete()
             return Response({"detail": f"Canteen {canteen_name} deleted successfully."})


### PR DESCRIPTION
## What changed
- fixed the admin canteen detail handler to use the routed `pk` parameter for freeze and delete actions
- added regression tests for admin canteen freeze and delete

## Why
Issue #2 reported that admin dashboard actions for canteens were failing while freeze/delete should work from the Manage Canteens tab.

## Validation
- python manage.py test apps.users.tests
- live browser verification on http://localhost:48080/manager/admin
- confirmed existing canteens load
- confirmed creating a new canteen works
- confirmed the new canteen can be frozen, activated, and deleted
- confirmed mess freeze, activate, and delete already work as expected
