### PR TITLE
fix: issue 11 - improve app initial loading screen

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,8 +5,123 @@
     <link rel="icon" type="image/png" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Upside Dine - Campus Dining Platform</title>
+    <style>
+      :root {
+        --boot-bg: #050505;
+        --boot-panel: rgba(12, 12, 12, 0.94);
+        --boot-border: rgba(255, 255, 255, 0.08);
+        --boot-accent: #d45555;
+        --boot-accent-soft: rgba(212, 85, 85, 0.18);
+        --boot-text: #ffffff;
+        --boot-muted: #9b9b9b;
+      }
+
+      html,
+      body {
+        width: 100%;
+        min-height: 100%;
+        margin: 0;
+        background:
+          radial-gradient(circle at top, rgba(214, 52, 52, 0.14), transparent 30%),
+          linear-gradient(180deg, var(--boot-bg) 0%, #0b0b0b 100%);
+        color: var(--boot-text);
+      }
+
+      body {
+        overflow-x: hidden;
+        font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      #root {
+        min-height: 100vh;
+      }
+
+      .app-boot-splash {
+        position: fixed;
+        inset: 0;
+        z-index: 9999;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        background:
+          radial-gradient(circle at top, rgba(214, 52, 52, 0.14), transparent 30%),
+          linear-gradient(180deg, var(--boot-bg) 0%, #0b0b0b 100%);
+        transition: opacity 0.24s ease, visibility 0.24s ease;
+      }
+
+      .app-boot-splash--hidden {
+        opacity: 0;
+        visibility: hidden;
+        pointer-events: none;
+      }
+
+      .app-boot-splash__panel {
+        width: min(100%, 420px);
+        border-radius: 28px;
+        border: 1px solid var(--boot-border);
+        background: var(--boot-panel);
+        box-shadow: 0 18px 36px rgba(0, 0, 0, 0.28);
+        padding: 28px 24px;
+        text-align: center;
+      }
+
+      .app-boot-splash__logo {
+        width: 76px;
+        height: 76px;
+        border-radius: 24px;
+        display: block;
+        margin: 0 auto 18px;
+        box-shadow: 0 0 28px var(--boot-accent-soft);
+      }
+
+      .app-boot-splash__title {
+        margin: 0 0 10px;
+        font-size: 1.5rem;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+      }
+
+      .app-boot-splash__subtitle {
+        margin: 0;
+        color: var(--boot-muted);
+        font-size: 0.95rem;
+      }
+
+      .app-boot-splash__spinner {
+        width: 42px;
+        height: 42px;
+        margin: 22px auto 0;
+        border-radius: 50%;
+        border: 3px solid rgba(255, 255, 255, 0.12);
+        border-top-color: var(--boot-accent);
+        animation: app-boot-spin 0.8s linear infinite;
+      }
+
+      @keyframes app-boot-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .app-boot-splash,
+        .app-boot-splash__spinner {
+          transition: none;
+          animation: none;
+        }
+      }
+    </style>
   </head>
   <body>
+    <div id="app-boot-splash" class="app-boot-splash" aria-hidden="true">
+      <div class="app-boot-splash__panel">
+        <img class="app-boot-splash__logo" src="/logo.png" alt="" />
+        <p class="app-boot-splash__title">Upside Dine</p>
+        <p class="app-boot-splash__subtitle">Loading your campus dining workspace...</p>
+        <div class="app-boot-splash__spinner"></div>
+      </div>
+    </div>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,8 +15,15 @@ body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
     'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
+  background: #0a0a0a;
+  color: #ffffff;
+  overflow-x: hidden;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+#root {
+  min-height: 100vh;
 }
 
 code {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,26 +1,32 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import axios from 'axios';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App.jsx';
 import { configureAxiosAuth } from './lib/auth';
 import './index.css';
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 1,
-      refetchOnWindowFocus: false,
-    },
-  },
-});
-
 configureAxiosAuth(axios);
 
-ReactDOM.createRoot(document.getElementById('root')).render(
+const rootElement = document.getElementById('root');
+const bootSplash = document.getElementById('app-boot-splash');
+
+const dismissBootSplash = () => {
+  if (!bootSplash) {
+    return;
+  }
+
+  bootSplash.classList.add('app-boot-splash--hidden');
+  window.setTimeout(() => {
+    bootSplash.remove();
+  }, 260);
+};
+
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
+    <App />
   </React.StrictMode>
 );
+
+window.requestAnimationFrame(() => {
+  window.requestAnimationFrame(dismissBootSplash);
+});


### PR DESCRIPTION
## What changed
- added an immediate branded boot splash in `index.html` so the app no longer flashes a plain white page before React loads
- added critical dark background styles to the startup CSS path
- removed the redundant outer React Query provider in `main.jsx` to trim unnecessary bootstrap work

## Why
Issue #11 reported that the app briefly showed a blank white page on first open before the real screen appeared.

## Validation
- npm run build
- confirmed the served HTML now includes the boot splash markup and dark boot styles at `http://localhost:48080/auth`
- live local app updated in `Upside-Dine-deployment_v4` with the same boot splash changes for manual verification
