### PR TITLE
fix: issues 51 and 40 - pay later checkout and payment language

### DIFF
--- a/backend/apps/canteen/serializers.py
+++ b/backend/apps/canteen/serializers.py
@@ -55,9 +55,24 @@ class CanteenListSerializer(serializers.ModelSerializer):
 
 class CanteenDetailSerializer(CanteenListSerializer):
     categories = CanteenMenuCategorySerializer(many=True, read_only=True)
+    payment_config = serializers.SerializerMethodField()
 
     class Meta(CanteenListSerializer.Meta):
-        fields = CanteenListSerializer.Meta.fields + ["categories"]
+        fields = CanteenListSerializer.Meta.fields + ["categories", "payment_config"]
+
+    def get_payment_config(self, obj):
+        config = getattr(obj, "payment_config", None)
+        if not config:
+            return {
+                "payment_mode": CanteenPaymentConfig.PAYMENT_MODE_BOTH,
+                "upi_id": "",
+                "qr_image_url": "",
+            }
+        return {
+            "payment_mode": config.payment_mode,
+            "upi_id": config.upi_id,
+            "qr_image_url": config.qr_image_url,
+        }
 
 
 class CategoryWithItemsSerializer(serializers.ModelSerializer):

--- a/backend/apps/canteen/tests.py
+++ b/backend/apps/canteen/tests.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from django.test import TestCase
 from rest_framework.test import APITestCase
 
-from .models import Canteen
+from .models import Canteen, CanteenPaymentConfig
 from apps.users.models import Role, Staff, User
 from .models import CanteenMenuCategory, CanteenMenuItem
 
@@ -85,3 +85,50 @@ class CanteenManagerMenuApiTests(APITestCase):
         menu_item.refresh_from_db()
         self.assertEqual(menu_item.category.category_name, "Beverages")
         self.assertEqual(response.data["category_name"], "Beverages")
+
+
+class CanteenDetailPaymentConfigApiTests(APITestCase):
+    def setUp(self):
+        self.student_role = Role.objects.create(role_name="student")
+        self.student_user = User.objects.create_user(
+            email="issue51.student@iitk.ac.in",
+            password="password123",
+            role=self.student_role,
+            is_active=True,
+            is_verified=True,
+        )
+        self.canteen = Canteen.objects.create(name="Issue 51 Canteen", location="Hall 5")
+        self.client.force_authenticate(user=self.student_user)
+
+    def test_detail_returns_default_payment_config_when_none_saved(self):
+        response = self.client.get(f"/api/canteens/{self.canteen.id}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data["payment_config"],
+            {
+                "payment_mode": CanteenPaymentConfig.PAYMENT_MODE_BOTH,
+                "upi_id": "",
+                "qr_image_url": "",
+            },
+        )
+
+    def test_detail_returns_saved_payment_config(self):
+        CanteenPaymentConfig.objects.create(
+            canteen=self.canteen,
+            payment_mode=CanteenPaymentConfig.PAYMENT_MODE_CASH,
+            upi_id="issue51@upi",
+            qr_image_url="https://example.com/issue51-qr.png",
+        )
+
+        response = self.client.get(f"/api/canteens/{self.canteen.id}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data["payment_config"],
+            {
+                "payment_mode": CanteenPaymentConfig.PAYMENT_MODE_CASH,
+                "upi_id": "issue51@upi",
+                "qr_image_url": "https://example.com/issue51-qr.png",
+            },
+        )

--- a/frontend/src/features/canteen/components/OrderConfirmation.jsx
+++ b/frontend/src/features/canteen/components/OrderConfirmation.jsx
@@ -5,6 +5,8 @@ import '../canteen.css';
 export default function OrderConfirmation({ order, onClose }) {
   if (!order) return null;
 
+  const isPayLaterOrder = order.checkout_payment_method === 'cash';
+
   return (
     <div className="canteen-confirmation">
       <motion.div
@@ -19,6 +21,24 @@ export default function OrderConfirmation({ order, onClose }) {
           Order #{order.id} has been placed successfully.<br />
           Estimated ready time: {order.estimated_ready_time || '15-20 mins'}
         </p>
+
+        {isPayLaterOrder ? (
+          <div
+            style={{
+              background: '#20170d',
+              border: '1px solid #8b6b33',
+              borderRadius: 12,
+              padding: 12,
+              marginBottom: 16,
+              color: '#f0d28a',
+              fontSize: 13,
+              lineHeight: 1.5,
+            }}
+          >
+            Pay Later selected. Please pay at the canteen counter
+            {order.order_type === 'delivery' ? ' or on delivery' : ''}.
+          </div>
+        ) : null}
 
         <div style={{
           background: '#1a1a1a', border: '1px solid #333', borderRadius: 12,

--- a/frontend/src/features/canteen/components/PaymentModal.jsx
+++ b/frontend/src/features/canteen/components/PaymentModal.jsx
@@ -14,7 +14,16 @@ const loadRazorpay = () =>
     document.body.appendChild(script);
   });
 
-export default function PaymentModal({ amount, orderId, onSuccess, onClose }) {
+const getPaymentErrorMessage = (error, fallback) =>
+  error?.response?.data?.detail || fallback;
+
+const normalizeCheckoutLanguage = (language) => {
+  const normalized = String(language || 'en').trim().toLowerCase();
+  const supportedLanguages = new Set(['en', 'hi', 'ben', 'mar', 'guj', 'tam', 'tel']);
+  return supportedLanguages.has(normalized) ? normalized : 'en';
+};
+
+export default function PaymentModal({ amount, orderId, language = 'en', user = null, onSuccess, onClose }) {
   const [loading, setLoading] = useState(false);
   const { mutateAsync: createPayment } = useCreatePayment();
   const { mutateAsync: verifyPayment } = useVerifyPayment();
@@ -28,6 +37,7 @@ export default function PaymentModal({ amount, orderId, onSuccess, onClose }) {
       const res = await createPayment({ order_id: orderId, amount });
       const rzpOrderId = res.payment?.razorpay_order_id || res.razorpay_order?.id;
       const rzpAmount = res.razorpay_order?.amount || amount * 100;
+      const selectedLanguage = normalizeCheckoutLanguage(language);
       const options = {
         key: import.meta.env.VITE_RAZORPAY_KEY_ID || res.razorpay_key_id,
         amount: rzpAmount,
@@ -35,6 +45,16 @@ export default function PaymentModal({ amount, orderId, onSuccess, onClose }) {
         name: 'Upside Dine',
         description: 'Canteen Order Payment',
         order_id: rzpOrderId,
+        prefill: {
+          name: user?.profile?.full_name || user?.email?.split('@')[0] || 'Student',
+          email: user?.email || '',
+          contact: user?.phone || '',
+        },
+        config: {
+          display: {
+            language: selectedLanguage,
+          },
+        },
         handler: async (response) => {
           try {
             await verifyPayment({
@@ -43,14 +63,16 @@ export default function PaymentModal({ amount, orderId, onSuccess, onClose }) {
               razorpay_signature: response.razorpay_signature,
             });
             onSuccess();
-          } catch { alert('Payment verification failed'); }
+          } catch (error) {
+            alert(getPaymentErrorMessage(error, 'Payment verification failed'));
+          }
         },
         modal: { ondismiss: () => setLoading(false) },
         theme: { color: '#d45555' },
       };
       new window.Razorpay(options).open();
-    } catch {
-      alert('Payment initiation failed');
+    } catch (error) {
+      alert(getPaymentErrorMessage(error, 'Payment initiation failed'));
       setLoading(false);
     }
   };

--- a/frontend/src/features/canteen/pages/CheckoutPage.jsx
+++ b/frontend/src/features/canteen/pages/CheckoutPage.jsx
@@ -1,8 +1,10 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, CreditCard, Wallet } from 'lucide-react';
 import { useCartStore } from '../../../stores/cartStore';
+import { useCurrentUser } from '../../../hooks/useCurrentUser';
 import { usePlaceOrder } from '../hooks/usePlaceOrder';
+import { useCanteenDetail } from '../hooks/useCanteenDetail';
 import PaymentModal from '../components/PaymentModal';
 import OrderConfirmation from '../components/OrderConfirmation';
 import {
@@ -11,6 +13,68 @@ import {
   sanitizeMultilineText,
 } from '../../../lib/formValidation';
 import '../canteen.css';
+
+const DEFAULT_PAYMENT_CONFIG = {
+  payment_mode: 'both',
+  upi_id: '',
+  qr_image_url: '',
+};
+
+const CHECKOUT_LANGUAGE_OPTIONS = [
+  { value: 'en', label: 'English' },
+  { value: 'hi', label: 'Hindi' },
+  { value: 'ben', label: 'Bengali' },
+  { value: 'mar', label: 'Marathi' },
+  { value: 'guj', label: 'Gujarati' },
+  { value: 'tam', label: 'Tamil' },
+  { value: 'tel', label: 'Telugu' },
+];
+
+const resolveInitialCheckoutLanguage = () => {
+  if (typeof navigator === 'undefined') {
+    return 'en';
+  }
+
+  const locales = [...(navigator.languages || []), navigator.language].filter(Boolean);
+  for (const locale of locales) {
+    const normalizedLocale = String(locale).toLowerCase();
+    if (normalizedLocale.startsWith('hi')) {
+      return 'hi';
+    }
+    if (normalizedLocale.startsWith('bn')) {
+      return 'ben';
+    }
+    if (normalizedLocale.startsWith('mr')) {
+      return 'mar';
+    }
+    if (normalizedLocale.startsWith('gu')) {
+      return 'guj';
+    }
+    if (normalizedLocale.startsWith('ta')) {
+      return 'tam';
+    }
+    if (normalizedLocale.startsWith('te')) {
+      return 'tel';
+    }
+  }
+
+  return 'en';
+};
+
+const PAYMENT_METHOD_LABELS = {
+  online: 'Pay Online',
+  cash: 'Pay Later',
+};
+
+const getPaymentHelpText = (paymentMethod, orderType) => {
+  if (paymentMethod === 'cash') {
+    return orderType === 'delivery'
+      ? 'Place the order now and pay when it is delivered.'
+      : 'Place the order now and pay at the canteen counter during pickup.';
+  }
+
+  return 'You will complete the payment inside Razorpay after the order is placed.';
+};
 
 export default function CheckoutPage() {
   const navigate = useNavigate();
@@ -26,6 +90,8 @@ export default function CheckoutPage() {
   const [orderPlaced, setOrderPlaced] = useState(false);
   const [orderData, setOrderData] = useState(null);
   const [submitting, setSubmitting] = useState(false);
+  const [paymentMethod, setPaymentMethod] = useState('online');
+  const [checkoutLanguage, setCheckoutLanguage] = useState(resolveInitialCheckoutLanguage);
 
   const canteenParam = searchParams.get('canteen');
   const parsedCanteenId = canteenParam ? Number(canteenParam) : null;
@@ -37,6 +103,25 @@ export default function CheckoutPage() {
         : null;
   const cart = useCartStore((state) => (canteenId ? state.getCart(canteenId) : []));
   const total = useCartStore((state) => (canteenId ? state.getTotal(canteenId) : 0));
+  const { data: currentUser } = useCurrentUser({ enabled: Boolean(canteenId) });
+  const { data: canteen } = useCanteenDetail(canteenId);
+
+  const paymentConfig = canteen?.payment_config || DEFAULT_PAYMENT_CONFIG;
+  const availablePaymentMethods = useMemo(() => {
+    if (paymentConfig.payment_mode === 'cash') {
+      return ['cash'];
+    }
+    if (paymentConfig.payment_mode === 'online') {
+      return ['online'];
+    }
+    return ['online', 'cash'];
+  }, [paymentConfig.payment_mode]);
+
+  useEffect(() => {
+    if (!availablePaymentMethods.includes(paymentMethod)) {
+      setPaymentMethod(availablePaymentMethods[0] || 'online');
+    }
+  }, [availablePaymentMethods, paymentMethod]);
 
   const handlePlaceOrder = async () => {
     setSubmitting(true);
@@ -57,12 +142,27 @@ export default function CheckoutPage() {
       if (orderType === 'prebook' && scheduledTime) {
         payload.scheduled_time = scheduledTime;
       }
+
       const order = await placeOrder(payload);
-      setOrderData(order);
+      const orderWithCheckoutMeta = {
+        ...order,
+        checkout_payment_method: paymentMethod,
+      };
+      setOrderData(orderWithCheckoutMeta);
+
+      if (paymentMethod === 'cash') {
+        setOrderPlaced(true);
+        clearCart(canteenId);
+        return;
+      }
+
       setPaymentOpen(true);
     } catch (err) {
       const errData = err.response?.data;
-      const msg = typeof errData === 'object' ? JSON.stringify(errData) : (errData || 'Failed to place order');
+      const msg =
+        typeof errData === 'object'
+          ? JSON.stringify(errData)
+          : errData || 'Failed to place order';
       alert(msg);
     } finally {
       setSubmitting(false);
@@ -71,11 +171,18 @@ export default function CheckoutPage() {
 
   if (!canteenId && cartCanteenIds.length > 1) {
     return (
-      <div className="canteen-page" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div
+        className="canteen-page"
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
         <div className="canteen-empty">
-          <div className="canteen-empty__icon">ðŸ›’</div>
+          <div className="canteen-empty__icon">Cart</div>
           <p className="canteen-empty__text">Open checkout from a specific canteen cart.</p>
-          <button className="canteen-btn-small canteen-btn-small--primary" onClick={() => navigate('/canteens')} style={{ marginTop: 16 }}>
+          <button
+            className="canteen-btn-small canteen-btn-small--primary"
+            onClick={() => navigate('/canteens')}
+            style={{ marginTop: 16 }}
+          >
             Browse Canteens
           </button>
         </div>
@@ -85,11 +192,20 @@ export default function CheckoutPage() {
 
   if (cart.length === 0 && !orderPlaced) {
     return (
-      <div className="canteen-page" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <div
+        className="canteen-page"
+        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      >
         <div className="canteen-empty">
-          <div className="canteen-empty__icon">🛒</div>
+          <div className="canteen-empty__icon">Cart</div>
           <p className="canteen-empty__text">Cart is empty</p>
-          <button className="canteen-btn-small canteen-btn-small--primary" onClick={() => navigate(canteenId ? `/canteens/${canteenId}` : '/canteens')} style={{ marginTop: 16 }}>Browse Menu</button>
+          <button
+            className="canteen-btn-small canteen-btn-small--primary"
+            onClick={() => navigate(canteenId ? `/canteens/${canteenId}` : '/canteens')}
+            style={{ marginTop: 16 }}
+          >
+            Browse Menu
+          </button>
         </div>
       </div>
     );
@@ -97,75 +213,198 @@ export default function CheckoutPage() {
 
   return (
     <div className="canteen-checkout">
-      <button onClick={() => navigate(-1)} style={{ background: 'transparent', border: 'none', color: '#999', fontSize: 14, cursor: 'pointer', marginBottom: 16, display: 'flex', alignItems: 'center', gap: 6 }}>
+      <button
+        onClick={() => navigate(-1)}
+        style={{
+          background: 'transparent',
+          border: 'none',
+          color: '#999',
+          fontSize: 14,
+          cursor: 'pointer',
+          marginBottom: 16,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+        }}
+      >
         <ArrowLeft size={16} /> Back
       </button>
 
       <h2 style={{ fontSize: 20, fontWeight: 700, marginBottom: 20 }}>Checkout</h2>
 
-      {/* Order Type */}
       <div className="canteen-checkout__section">
         <p className="canteen-checkout__section-title">Order Type</p>
         <div className="canteen-filter-tabs">
           {['pickup', 'delivery'].map((type) => (
-            <button key={type} className={`canteen-filter-tab ${orderType === type ? 'active' : ''}`} onClick={() => setOrderType(type)} style={{ textTransform: 'capitalize' }}>
+            <button
+              key={type}
+              className={`canteen-filter-tab ${orderType === type ? 'active' : ''}`}
+              onClick={() => setOrderType(type)}
+              style={{ textTransform: 'capitalize' }}
+            >
               {type}
             </button>
           ))}
         </div>
       </div>
 
-      {/* Delivery Address */}
       {orderType === 'delivery' && (
         <div className="canteen-checkout__section">
           <p className="canteen-checkout__section-title">Delivery Address</p>
-          <input className="canteen-checkout__input" value={address} onChange={(e) => setAddress(sanitizeLocationText(e.target.value, FIELD_LIMITS.address))} placeholder="Room no, Hall name..." maxLength={FIELD_LIMITS.address} autoComplete="street-address" />
+          <input
+            className="canteen-checkout__input"
+            value={address}
+            onChange={(event) =>
+              setAddress(sanitizeLocationText(event.target.value, FIELD_LIMITS.address))
+            }
+            placeholder="Room no, Hall name..."
+            maxLength={FIELD_LIMITS.address}
+            autoComplete="street-address"
+          />
         </div>
       )}
 
-      {/* Scheduled Time */}
       {orderType === 'prebook' && (
         <div className="canteen-checkout__section">
           <p className="canteen-checkout__section-title">Schedule Time</p>
-          <input className="canteen-checkout__input" type="datetime-local" value={scheduledTime} onChange={(e) => setScheduledTime(e.target.value)} />
+          <input
+            className="canteen-checkout__input"
+            type="datetime-local"
+            value={scheduledTime}
+            onChange={(event) => setScheduledTime(event.target.value)}
+          />
         </div>
       )}
 
-      {/* Notes */}
       <div className="canteen-checkout__section">
-        <p className="canteen-checkout__section-title">Special Instructions</p>
-        <textarea className="canteen-checkout__input" value={notes} onChange={(e) => setNotes(sanitizeMultilineText(e.target.value, FIELD_LIMITS.notes))} placeholder="e.g. less spicy, no onions..." rows={2} maxLength={FIELD_LIMITS.notes} style={{ resize: 'none' }} />
+        <p className="canteen-checkout__section-title">Payment Method</p>
+        <div className="canteen-filter-tabs">
+          {availablePaymentMethods.map((method) => (
+            <button
+              key={method}
+              className={`canteen-filter-tab ${paymentMethod === method ? 'active' : ''}`}
+              onClick={() => setPaymentMethod(method)}
+              style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+            >
+              {method === 'online' ? <CreditCard size={14} /> : <Wallet size={14} />}
+              {PAYMENT_METHOD_LABELS[method]}
+            </button>
+          ))}
+        </div>
+        <p style={{ color: '#9b9b9b', fontSize: 13, marginTop: 10, lineHeight: 1.5 }}>
+          {getPaymentHelpText(paymentMethod, orderType)}
+        </p>
+        {paymentMethod === 'cash' ? (
+          <p style={{ color: '#d9b06f', fontSize: 12, marginTop: 6 }}>
+            This canteen accepts pay-later orders through its cash payment mode.
+          </p>
+        ) : null}
       </div>
 
-      {/* Order Summary */}
+      {paymentMethod === 'online' ? (
+        <div className="canteen-checkout__section">
+          <p className="canteen-checkout__section-title">Payment Language</p>
+          <select
+            className="canteen-checkout__input"
+            value={checkoutLanguage}
+            onChange={(event) => setCheckoutLanguage(event.target.value)}
+          >
+            {CHECKOUT_LANGUAGE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <p style={{ color: '#9b9b9b', fontSize: 12, marginTop: 10, lineHeight: 1.5 }}>
+            Your selection is passed into Razorpay when the payment window opens.
+          </p>
+        </div>
+      ) : null}
+
+      <div className="canteen-checkout__section">
+        <p className="canteen-checkout__section-title">Special Instructions</p>
+        <textarea
+          className="canteen-checkout__input"
+          value={notes}
+          onChange={(event) =>
+            setNotes(sanitizeMultilineText(event.target.value, FIELD_LIMITS.notes))
+          }
+          placeholder="e.g. less spicy, no onions..."
+          rows={2}
+          maxLength={FIELD_LIMITS.notes}
+          style={{ resize: 'none' }}
+        />
+      </div>
+
       <div className="canteen-checkout__section">
         <p className="canteen-checkout__section-title">Order Summary</p>
         {cart.map((item) => (
-          <div key={item.id} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 14, marginBottom: 8, color: '#ccc' }}>
-            <span>{item.name} × {item.quantity}</span>
-            <span style={{ color: '#d45555' }}>₹{item.price * item.quantity}</span>
+          <div
+            key={item.id}
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              fontSize: 14,
+              marginBottom: 8,
+              color: '#ccc',
+            }}
+          >
+            <span>
+              {item.name} x {item.quantity}
+            </span>
+            <span style={{ color: '#d45555' }}>Rs {item.price * item.quantity}</span>
           </div>
         ))}
-        <div style={{ borderTop: '1px solid #333', marginTop: 12, paddingTop: 12, display: 'flex', justifyContent: 'space-between', fontWeight: 700, fontSize: 16 }}>
+        <div
+          style={{
+            borderTop: '1px solid #333',
+            marginTop: 12,
+            paddingTop: 12,
+            display: 'flex',
+            justifyContent: 'space-between',
+            fontWeight: 700,
+            fontSize: 16,
+          }}
+        >
           <span>Total</span>
-          <span style={{ color: '#d45555' }}>₹{total}</span>
+          <span style={{ color: '#d45555' }}>Rs {total}</span>
         </div>
       </div>
 
-      {/* Submit */}
-      <button className="canteen-checkout__submit" onClick={handlePlaceOrder} disabled={submitting} style={{ opacity: submitting ? 0.6 : 1 }}>
-        {submitting ? 'Placing Order...' : `Continue to Payment • ₹${total}`}
+      <button
+        className="canteen-checkout__submit"
+        onClick={handlePlaceOrder}
+        disabled={submitting}
+        style={{ opacity: submitting ? 0.6 : 1 }}
+      >
+        {submitting
+          ? 'Placing Order...'
+          : paymentMethod === 'cash'
+            ? `Place Order and Pay Later - Rs ${total}`
+            : `Continue to Payment - Rs ${total}`}
       </button>
 
-      {/* Payment Modal */}
-      {paymentOpen && orderData && (
-        <PaymentModal amount={orderData.total_amount} orderId={orderData.id} onSuccess={() => { setPaymentOpen(false); setOrderPlaced(true); clearCart(canteenId); }} onClose={() => setPaymentOpen(false)} />
-      )}
+      {paymentOpen && orderData ? (
+        <PaymentModal
+          amount={orderData.total_amount}
+          orderId={orderData.id}
+          language={checkoutLanguage}
+          user={currentUser}
+          onSuccess={() => {
+            setPaymentOpen(false);
+            setOrderPlaced(true);
+            clearCart(canteenId);
+          }}
+          onClose={() => setPaymentOpen(false)}
+        />
+      ) : null}
 
-      {/* Confirmation */}
-      {orderPlaced && orderData && (
-        <OrderConfirmation order={orderData} onClose={() => navigate(`/orders/${orderData.id}`)} />
-      )}
+      {orderPlaced && orderData ? (
+        <OrderConfirmation
+          order={orderData}
+          onClose={() => navigate(`/orders/${orderData.id}`)}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- honor canteen payment config in student checkout so cash/pay-later orders can be placed without opening Razorpay
- add a checkout language selector and pass the selected language into Razorpay config along with student prefill details
- expose student-safe payment config from canteen detail and cover it with backend tests

## Testing
- python manage.py test apps.canteen.tests
- npm run build
- live browser verification for pay-later checkout and Razorpay language config